### PR TITLE
Add design contract skill and DESIGN.md template

### DIFF
--- a/.agents/skills/design-system-authoring/SKILL.md
+++ b/.agents/skills/design-system-authoring/SKILL.md
@@ -1,0 +1,194 @@
+# Design System Authoring
+
+## Purpose
+
+Use this skill before UI work, visual refactors, landing page redesigns, admin interface cleanup, or when creating or updating a project `DESIGN.md`.
+
+## Goal
+
+Turn vague visual direction into a small design contract that agents can follow without inventing random spacing, colors, shadows, layouts, or component behavior.
+
+This skill is not for cloning another brand.
+It is for creating a project-specific visual operating system.
+
+## When to use
+
+Use this skill when the task includes any of:
+
+- page layout
+- UI components
+- Tailwind classes
+- spacing, radius, shadows, borders, or motion
+- forms, wizards, cards, tables, modals, menus, or admin screens
+- dark mode or theme presets
+- making a design more polished, premium, clean, stylish, mobile-first, or conversion-focused
+
+## Inputs
+
+Collect only what is needed:
+
+- product type
+- target audience
+- primary user action
+- brand mood
+- existing colors or assets
+- current UI problems
+- framework and component stack
+- pages or components in scope
+- non-negotiable product constraints
+
+If exact values are missing, create practical defaults and record them in `DESIGN.md` instead of scattering one-off choices through the codebase.
+
+## Required output
+
+For design-system work, create or update `DESIGN.md` in the product repository.
+
+For implementation work, include a short design compliance note:
+
+- design source used
+- page or component type
+- tokens or components touched
+- visual risks
+- manual checks performed
+
+## Design contract layers
+
+A useful `DESIGN.md` should define these layers, in this order:
+
+1. Product and brand direction
+2. Page type priorities
+3. Design tokens
+4. Layout rules
+5. Component rules
+6. Responsive behavior
+7. Motion rules
+8. Accessibility baseline
+9. Do and don't rules
+10. Visual QA checklist
+
+Do not start with random component styling before the direction and tokens are clear.
+
+## Page type decision table
+
+| Page type | Main job | Layout priority | Common failure to avoid |
+|---|---|---|---|
+| Marketing landing | Convert and build trust | Hero, proof, CTA, service clarity | Generic SaaS look with weak local trust |
+| Service page | Explain one offer and push contact | Clear sections, local proof, repeated CTA | Long text wall with no action path |
+| Location page | Rank and feel local | Local headings, service cards, area proof | Duplicate city pages with thin copy |
+| Calculator or wizard | Guide step-by-step input | One decision per step, sticky summary | Too many controls visible at once |
+| Admin dashboard | Manage data fast | Density, scan speed, safe actions | Pretty cards that hide operational state |
+| Menu or catalog | Browse and choose quickly | Categories, item cards, prices, mobile readability | Desktop-first tables on phones |
+| Documentation | Teach and unblock | Headings, examples, code blocks | Decorative layout fighting readability |
+| Experimental brand page | Create emotion and memory | Strong art direction, controlled motion | Effects that break usability |
+
+## Design intensity table
+
+| Intensity | Use when | Visual behavior | Risk |
+|---|---|---|---|
+| Quiet | Admin, docs, data-heavy tools | Neutral colors, tight spacing, minimal effects | Can feel unfinished |
+| Professional | Local services, B2B, lead gen | Strong CTA, trust blocks, clean sections | Can become generic |
+| Premium | Hospitality, high-ticket services | More whitespace, larger type, richer imagery | Can reduce information density |
+| Expressive | Bars, events, creative brands | Strong color, motion, custom hero | Can hurt clarity |
+| Experimental | Visual demos, art-heavy concepts | Unusual layout and effects | Can break performance and mobile UX |
+
+Choose one primary intensity and one secondary accent. Do not mix all modes on one page.
+
+## Token minimum
+
+Every project `DESIGN.md` should define at least:
+
+| Token group | Required decisions |
+|---|---|
+| Color | background, surface, text, muted text, border, primary CTA, secondary CTA, danger, success |
+| Typography | font family, heading scale, body size, line height, label style |
+| Spacing | base scale, section padding, card padding, grid gap, form gap |
+| Radius | button, card, modal, input, pill |
+| Shadow | none, soft, elevated, overlay |
+| Border | default border color, strong border color, divider behavior |
+| Motion | duration, easing, allowed effects, reduced-motion fallback |
+| Breakpoints | mobile, tablet, desktop behavior |
+
+## Practical spacing scale
+
+Use a small spacing scale unless the project already has one:
+
+| Name | Value | Use |
+|---|---:|---|
+| 0 | 0 | Reset and flush edges |
+| 1 | 4px | Tiny icon and label gaps |
+| 2 | 8px | Compact internal gaps |
+| 3 | 12px | Button and form micro spacing |
+| 4 | 16px | Default component padding |
+| 6 | 24px | Card padding and grid gaps |
+| 8 | 32px | Section internal spacing |
+| 12 | 48px | Mobile section padding |
+| 16 | 64px | Desktop section padding |
+| 24 | 96px | Large hero rhythm only |
+
+Avoid arbitrary values like 17px, 23px, 37px unless matching an existing system.
+
+## Component decision table
+
+| Component | Must define | Must not do |
+|---|---|---|
+| Button | hierarchy, sizes, hover, disabled, loading | invent a new style per section |
+| Card | padding, radius, border, shadow, image behavior | mix 5 shadow depths on one page |
+| Form | label placement, error state, helper text, focus state | hide errors or rely only on placeholder text |
+| Table | density, mobile fallback, row actions, empty state | force wide tables on mobile |
+| Modal | width, backdrop, close behavior, scroll behavior | create full-screen chaos without reason |
+| Navigation | active state, mobile menu, CTA placement | move primary CTA unpredictably |
+| Hero | headline rhythm, image or background rules, CTA group | overload with every possible message |
+| Wizard | step state, back/next behavior, summary block | expose all steps at once on mobile |
+| Theme switcher | tokens affected, preview behavior, persistence | change random classes outside tokens |
+
+## Agent procedure
+
+1. Read existing `AGENTS.md` and `DESIGN.md` if present.
+2. Inspect the current UI patterns before changing files.
+3. Identify the page type and design intensity.
+4. Reuse existing tokens and components first.
+5. If no system exists, create the smallest useful `DESIGN.md` first.
+6. Implement with shared classes, component variants, or token mapping.
+7. Avoid one-off Tailwind chains when a shared pattern should exist.
+8. Check mobile first, then desktop.
+9. Record visual risks and manual checks.
+10. Do not call the design done if spacing, state, and mobile behavior were not checked.
+
+## Anti-patterns
+
+Avoid:
+
+- copying another brand instead of defining this project
+- random gradients added as decoration
+- inconsistent section padding
+- inconsistent card radius
+- buttons with different heights for the same role
+- tables that are unusable on mobile
+- modals with no scroll handling
+- animations that run forever or block reading
+- text contrast that looks fine only on one screen
+- adding a new UI library for a small styling task
+- hiding unfinished controls instead of making the contract explicit
+
+## Visual QA checklist
+
+Before sign-off, answer:
+
+- Does the UI follow `DESIGN.md`?
+- Are spacing and radius consistent across repeated components?
+- Is the primary action obvious on mobile?
+- Are forms usable with errors, loading, and disabled states?
+- Are tables or dense layouts usable on small screens?
+- Does motion respect reduced-motion behavior when relevant?
+- Did the change avoid unrelated visual rewrites?
+- Are any new tokens or component variants documented?
+
+## Minimal verdict format
+
+- Design source
+- Page type
+- Tokens touched
+- Components touched
+- Mobile check
+- Risks
+- Verdict: pass, partial, or fail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ The priority is not verbosity. The priority is safe execution, branch integrity,
 6. Keep durable handoff state in files, not only in chat history.
 7. Separate tactical handoff from long-term project history.
 8. When uncertain, preserve information rather than compressing it away.
+9. For UI work, use an explicit design contract instead of inventing one-off styling.
 
 ## Branch integrity minimum
 
@@ -45,6 +46,7 @@ Useful artifacts include:
 - branch state
 - merge preview notes
 - project chronicle
+- design contract
 
 Templates live in `templates/`.
 Skills live in `.agents/skills/`.
@@ -56,6 +58,7 @@ Skills live in `.agents/skills/`.
 - `session-handoff`
 - `project-chronicle`
 - `merge-preview-check`
+- `design-system-authoring`
 
 ## Authoring guidance
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -18,13 +18,22 @@ Copy only the layers you actually need.
 - proof-loop-verification
 - session-handoff
 
+For UI-heavy projects, also adopt:
+
+- design-system-authoring
+
 ## 4. Best first templates to adopt
 
 - BRANCH_STATE.md
 - HANDOFF.md
 - TASK_EVIDENCE.md
 
+For UI-heavy projects, also adopt:
+
+- DESIGN.md
+
 ## 5. Important rule
 
 This repository is not the source of truth for a product codebase.
 Each product repository should keep its own AGENTS.md and its own current state files.
+Each UI-heavy product repository should keep its own project-specific DESIGN.md.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Codex Playbook
 
-This repository contains a practical Codex playbook focused on safe code changes, branch integrity, handoffs, checkpoints, and durable project context.
+This repository contains a practical Codex playbook focused on safe code changes, branch integrity, handoffs, checkpoints, durable project context, and reusable design contracts for agent-driven UI work.
 
 ## Structure
 
 - `AGENTS.md` - root operating rules for Codex
 - `.agents/skills/` - on-demand skills for recurring workflows
-- `templates/` - reusable state and evidence templates
+- `templates/` - reusable state, evidence, and design contract templates
 - `.codex/` - local Codex config placeholders
 
 ## Goals
@@ -16,6 +16,7 @@ This repository contains a practical Codex playbook focused on safe code changes
 - make merge drift visible
 - require evidence before declaring work complete
 - keep durable session handoffs and project history
+- prevent random UI styling by using explicit `DESIGN.md` contracts
 
 ## Initial skills
 
@@ -24,5 +25,6 @@ This repository contains a practical Codex playbook focused on safe code changes
 - session handoff
 - project chronicle
 - merge preview check
+- design system authoring
 
 Adapt per repository instead of dumping everything into one giant prompt.

--- a/templates/DESIGN.md
+++ b/templates/DESIGN.md
@@ -1,0 +1,201 @@
+# DESIGN.md
+
+This file is the project design contract for AI-assisted UI work.
+It defines how the product should look, feel, and behave so agents do not invent random styling on every task.
+
+## Product direction
+
+| Field | Decision |
+|---|---|
+| Product | TODO |
+| Audience | TODO |
+| Primary action | TODO |
+| Brand mood | TODO |
+| Design intensity | Quiet / Professional / Premium / Expressive / Experimental |
+| Main visual risk | TODO |
+
+## Non-negotiables
+
+- Mobile-first layout.
+- Primary action must be obvious without hunting.
+- Repeated components must use the same spacing, radius, and state rules.
+- Do not clone another brand.
+- Do not add decorative effects that reduce readability or performance.
+- Do not introduce a new UI library unless the task explicitly requires it.
+
+## Page type priorities
+
+| Page type | Main job | Layout priority | Avoid |
+|---|---|---|---|
+| Marketing landing | Convert and build trust | Hero, proof, CTA, service clarity | Generic SaaS layout with weak trust |
+| Service page | Explain one offer and push contact | Clear sections, proof, repeated CTA | Long text wall with no action path |
+| Location page | Rank and feel local | Local headings, service cards, area proof | Thin duplicate pages |
+| Calculator or wizard | Guide input step by step | One decision per step, sticky summary | Showing every control at once on mobile |
+| Admin dashboard | Manage data fast | Scan speed, density, safe actions | Pretty cards hiding operational state |
+| Menu or catalog | Browse and choose quickly | Categories, item cards, prices | Desktop-first tables on phones |
+| Documentation | Teach and unblock | Headings, examples, code blocks | Decoration fighting readability |
+| Experimental page | Create memory and emotion | Strong art direction, controlled motion | Effects breaking usability |
+
+## Design tokens
+
+### Color
+
+| Token | Value | Use |
+|---|---|---|
+| background | TODO | App/page background |
+| surface | TODO | Cards, panels, elevated blocks |
+| surface-muted | TODO | Quiet sections, subtle panels |
+| text | TODO | Main readable text |
+| text-muted | TODO | Secondary text and helper copy |
+| border | TODO | Default dividers and card borders |
+| border-strong | TODO | Active or emphasized borders |
+| primary | TODO | Main CTA and primary highlights |
+| primary-hover | TODO | Main CTA hover state |
+| secondary | TODO | Secondary CTA or accent |
+| success | TODO | Success state |
+| warning | TODO | Warning state |
+| danger | TODO | Error or destructive action |
+
+### Typography
+
+| Token | Value | Use |
+|---|---|---|
+| font-body | TODO | Body and UI text |
+| font-heading | TODO | H1-H3 headings |
+| font-mono | TODO | Code, IDs, technical labels |
+| text-xs | 12px | Badges, helper text |
+| text-sm | 14px | Labels, compact UI |
+| text-base | 16px | Body text |
+| text-lg | 18px | Lead text |
+| h1 | TODO | Main page headline |
+| h2 | TODO | Section heading |
+| h3 | TODO | Card heading |
+| line-height-body | 1.5 | Body readability |
+| line-height-heading | 1.1-1.2 | Tight headings |
+
+### Spacing
+
+| Token | Value | Use |
+|---|---:|---|
+| space-0 | 0 | Reset and flush edges |
+| space-1 | 4px | Tiny icon and label gaps |
+| space-2 | 8px | Compact internal gaps |
+| space-3 | 12px | Button and form micro spacing |
+| space-4 | 16px | Default component padding |
+| space-6 | 24px | Card padding and grid gaps |
+| space-8 | 32px | Section internal spacing |
+| space-12 | 48px | Mobile section padding |
+| space-16 | 64px | Desktop section padding |
+| space-24 | 96px | Large hero rhythm only |
+
+### Radius
+
+| Token | Value | Use |
+|---|---:|---|
+| radius-sm | TODO | Badges, tiny controls |
+| radius-md | TODO | Inputs and buttons |
+| radius-lg | TODO | Cards |
+| radius-xl | TODO | Large panels |
+| radius-pill | 999px | Pills and rounded CTAs |
+
+### Shadow and elevation
+
+| Token | Value | Use |
+|---|---|---|
+| shadow-none | none | Flat UI |
+| shadow-soft | TODO | Default card elevation |
+| shadow-elevated | TODO | Floating panels, dropdowns |
+| shadow-overlay | TODO | Modals and high-focus surfaces |
+
+### Motion
+
+| Token | Value | Use |
+|---|---|---|
+| duration-fast | 120ms | Hover and active feedback |
+| duration-normal | 180ms | Menus, small transitions |
+| duration-slow | 320ms | Page-level or hero transitions |
+| easing-standard | ease-out | Default UI motion |
+| reduced-motion | required | Disable non-essential animation |
+
+## Layout rules
+
+| Area | Rule |
+|---|---|
+| Container | Use one consistent max width per page family. Do not invent section-specific widths. |
+| Section padding | Mobile first. Use larger vertical rhythm only where it improves scanning. |
+| Grid gap | Use tokenized gaps. Do not mix arbitrary values in repeated grids. |
+| Cards | Same card family must share radius, border, padding, and image behavior. |
+| Forms | Labels, errors, focus states, loading states, and disabled states must be visible. |
+| CTA | Primary action must remain visible and predictable on mobile. |
+| Empty states | Must explain what happened and what the user can do next. |
+
+## Component rules
+
+| Component | Required behavior | Forbidden behavior |
+|---|---|---|
+| Button | Define primary, secondary, ghost, danger, disabled, loading | New button style per section |
+| Card | Define padding, border, radius, media handling | Random shadows or inconsistent radius |
+| Form input | Label, helper text, error, focus, disabled | Placeholder-only labels |
+| Table | Dense desktop, card/list fallback on mobile | Horizontal overflow as the only mobile plan |
+| Modal | Backdrop, close, max width, scroll behavior | Content trapped off-screen |
+| Navigation | Active state, mobile state, CTA placement | Moving CTA unpredictably |
+| Hero | One main message, one primary action, optional secondary action | Every selling point in the hero |
+| Wizard | Current step, progress, back/next, summary | All steps visible at once on mobile |
+
+## Responsive behavior
+
+| Breakpoint | Behavior |
+|---|---|
+| Mobile | One-column by default, obvious CTA, no tiny tap targets |
+| Tablet | Two-column where content benefits, preserve reading flow |
+| Desktop | Use wider grid only when it improves comprehension |
+
+Minimum tap target: 44px height or width for interactive controls.
+
+## Accessibility baseline
+
+- Text contrast must be readable against the actual background.
+- Focus states must be visible for keyboard users.
+- Inputs need programmatic labels.
+- Do not rely on color alone for errors or status.
+- Respect reduced motion for non-essential animations.
+- Images need useful alt text unless decorative.
+
+## Do and don't
+
+| Do | Don't |
+|---|---|
+| Reuse tokens and shared components | Scatter one-off Tailwind chains everywhere |
+| Keep repeated sections visually consistent | Make every block a different design system |
+| Make state visible | Hide loading, error, empty, or disabled states |
+| Check mobile first | Fix only desktop screenshots |
+| Document new variants | Add unexplained visual exceptions |
+| Use motion to clarify | Use motion as decoration that slows users down |
+
+## Visual QA checklist
+
+Before calling a UI task done:
+
+- [ ] The page follows this `DESIGN.md`.
+- [ ] Repeated components use consistent spacing, radius, borders, and shadows.
+- [ ] Primary CTA is obvious on mobile.
+- [ ] Forms have label, focus, error, loading, and disabled states where relevant.
+- [ ] Tables or dense layouts have a mobile plan.
+- [ ] Motion is controlled and has a reduced-motion fallback where relevant.
+- [ ] No unrelated visual rewrite was included.
+- [ ] New tokens or variants are documented here.
+
+## Design compliance note template
+
+```md
+## Design compliance
+
+- Design source: DESIGN.md
+- Page type:
+- Design intensity:
+- Tokens touched:
+- Components touched:
+- Mobile check:
+- Visual risks:
+- Verdict: pass / partial / fail
+```


### PR DESCRIPTION
## Summary

Adds a compact design-system layer for Codex-driven UI work:

- new skill: `.agents/skills/design-system-authoring/SKILL.md`
- new reusable template: `templates/DESIGN.md`
- README, Quickstart, and AGENTS index updates

## Why

The goal is not to copy third-party visual styles. The goal is to give agents a small, reusable design contract so they stop inventing random spacing, radius, component behavior, mobile rules, and visual states on every UI task.

## Scope

Only playbook and template files were changed.

## Verification

Reviewed the branch diff against `main`.

## Known risk

The branch is behind `main` by one commit in the compare result. The changed files are additive or small documentation edits, but merge drift should still be checked before merge.