### PR TITLE
Fix reusable Playwright dogfood action template

### DIFF
--- a/templates/DOGFOOD_GITHUB_ACTION.yml
+++ b/templates/DOGFOOD_GITHUB_ACTION.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  PREVIEW_URL: http://127.0.0.1:4321
+
 jobs:
   dogfood:
     runs-on: ubuntu-latest
@@ -30,10 +33,10 @@ jobs:
         run: npm run preview &
 
       - name: Wait for preview
-        run: npx wait-on http://127.0.0.1:4321
+        run: npx wait-on $PREVIEW_URL
 
       - name: Run dogfood QA
-        run: npm run qa:dogfood
+        run: npx playwright test tests/dogfood --reporter=html
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes two operational issues in the reusable Dogfood QA GitHub Actions template.

## Fixes

### 1. Configurable preview URL

The previous template hard-coded:

```text
http://127.0.0.1:4321
```

which incorrectly assumed Astro-style preview defaults.

The workflow now exposes:

```yaml
env:
  PREVIEW_URL: http://127.0.0.1:4321
```

and uses it for the wait-on check.

This makes the template reusable across:

- Astro
- Vite
- React
- custom preview servers
- Cloudflare local preview flows

## 2. Guaranteed Playwright HTML report generation

The previous template uploaded:

```text
playwright-report/
```

without guaranteeing the HTML reporter was enabled.

The workflow now explicitly runs:

```text
npx playwright test tests/dogfood --reporter=html
```

so uploaded artifacts reliably exist.

## Why

The original template was operationally close, but not fully deterministic for reusable CI/browser QA workflows.

These changes make the browser evidence pipeline:

- portable
- deterministic
- CI-friendly
- framework-agnostic
