### PR TITLE
Bind execution contracts to exact admissibility/profile evidence and enforce timestamped capability evidence

### DIFF
--- a/contracts/EXECUTABILITY_CONTRACT.md
+++ b/contracts/EXECUTABILITY_CONTRACT.md
@@ -38,6 +38,14 @@ It records:
 
 A capability profile is evidence about a runtime, not authority to use that capability.
 
+For deterministic admission, the profile freshness boundary contains timezone-aware
+`observed_at` and `valid_until` timestamps. `valid_until` must still be in the future.
+Every available capability cites a separately represented, `RESOLVED`
+`CAPABILITY_EVIDENCE` artifact embedded in `evidence_artifacts`; that artifact must
+name the same exact `runtime_identity`, prove the cited capability, and remain valid
+for the whole profile freshness boundary. An arbitrary or unresolved string is not
+capability evidence.
+
 ## ASSIGNMENT_ADMISSIBILITY
 
 An `ASSIGNMENT_ADMISSIBILITY` record binds an assignment draft to an exact destination and capability profile. It records:
@@ -50,6 +58,11 @@ An `ASSIGNMENT_ADMISSIBILITY` record binds an assignment draft to an exact desti
 - `ADMISSIBLE` or `NOT_ADMISSIBLE`.
 
 `ADMISSIBLE` is valid only when the unsatisfied set is empty. The deterministic reference implementation lives at `tools/executability.py`.
+
+An executable assignment carries `execution_contract.assignment_draft_ref` equal
+to the cited admissibility record's `assignment_draft_id`, plus the same exact
+`runtime_identity`. Matching destination labels alone do not establish either
+binding.
 
 ## Capability vocabulary
 

--- a/schemas/assignment-admissibility.schema.json
+++ b/schemas/assignment-admissibility.schema.json
@@ -3,7 +3,7 @@
   "$id": "project-resolver/assignment-admissibility.schema.json",
   "title": "ASSIGNMENT_ADMISSIBILITY",
   "type": "object",
-  "required": ["artifact_type","artifact_id","produced_by_role","assignment_id","input_state_ref","status","provenance","related_artifacts","assignment_draft_id","destination_id","capability_profile_ref","mandatory_actions","required_capabilities","available_capabilities","unsatisfied_required_capabilities","mandatory_evidence_paths","execution_mode"],
+  "required": ["artifact_type","artifact_id","produced_by_role","assignment_id","input_state_ref","status","provenance","related_artifacts","assignment_draft_id","destination_id","runtime_identity","capability_profile_ref","mandatory_actions","required_capabilities","available_capabilities","unsatisfied_required_capabilities","mandatory_evidence_paths","execution_mode"],
   "properties": {
     "artifact_type": {"const":"ASSIGNMENT_ADMISSIBILITY"},
     "artifact_id": {"type":"string","minLength":1},
@@ -15,6 +15,7 @@
     "related_artifacts": {"type":"array","items":{"type":"string"}},
     "assignment_draft_id": {"type":"string","minLength":1},
     "destination_id": {"type":"string","minLength":1},
+    "runtime_identity": {"type":"string","minLength":1},
     "capability_profile_ref": {"type":"string","minLength":1},
     "required_capabilities": {"type":"array","uniqueItems":true,"items":{"type":"string","minLength":1}},
     "available_capabilities": {"type":"array","uniqueItems":true,"items":{"type":"string","minLength":1}},

--- a/schemas/assignment.schema.json
+++ b/schemas/assignment.schema.json
@@ -22,9 +22,11 @@
     "result_to": {"type":"string","minLength":1},
     "execution_contract": {
       "type":"object",
-      "required":["destination_id","capability_profile_ref","admissibility_ref","proof_status","required_capabilities","unsatisfied_required_capabilities","mandatory_evidence_paths","execution_mode"],
+      "required":["assignment_draft_ref","destination_id","runtime_identity","capability_profile_ref","admissibility_ref","proof_status","required_capabilities","unsatisfied_required_capabilities","mandatory_evidence_paths","execution_mode"],
       "properties": {
+        "assignment_draft_ref":{"type":"string","minLength":1},
         "destination_id":{"type":"string","minLength":1},
+        "runtime_identity":{"type":"string","minLength":1},
         "capability_profile_ref":{"type":"string","minLength":1},
         "admissibility_ref":{"type":"string","minLength":1},
         "proof_status":{"const":"PROVEN"},

--- a/schemas/capability-profile.schema.json
+++ b/schemas/capability-profile.schema.json
@@ -3,14 +3,14 @@
   "$id": "project-resolver/capability-profile.schema.json",
   "title": "CAPABILITY_PROFILE",
   "type": "object",
-  "required": ["artifact_type","artifact_id","produced_by_role","assignment_id","input_state_ref","status","provenance","related_artifacts","destination_id","runtime_identity","available_capabilities","unavailable_capabilities","capability_evidence","freshness_boundary","limitations"],
+  "required": ["artifact_type","artifact_id","produced_by_role","assignment_id","input_state_ref","status","provenance","related_artifacts","destination_id","runtime_identity","available_capabilities","unavailable_capabilities","capability_evidence","evidence_artifacts","freshness_boundary","limitations"],
   "properties": {
     "artifact_type": {"const":"CAPABILITY_PROFILE"},
     "artifact_id": {"type":"string","minLength":1},
     "produced_by_role": {"type":"string","minLength":1},
     "assignment_id": {"type":["string","null"]},
     "input_state_ref": {"type":["string","null"]},
-    "status": {"type":"string","minLength":1},
+    "status": {"const":"CURRENT"},
     "provenance": {"type":"array","items":{"type":"string"}},
     "related_artifacts": {"type":"array","items":{"type":"string"}},
     "destination_id": {"type":"string","minLength":1},
@@ -37,7 +37,32 @@
         "additionalProperties": true
       }
     },
-    "freshness_boundary": {"type":"string","minLength":1},
+    "evidence_artifacts": {
+      "type":"array",
+      "items": {
+        "type":"object",
+        "required":["artifact_type","artifact_id","status","runtime_identity","capabilities","observed_at","valid_until"],
+        "properties": {
+          "artifact_type":{"const":"CAPABILITY_EVIDENCE"},
+          "artifact_id":{"type":"string","minLength":1},
+          "status":{"const":"RESOLVED"},
+          "runtime_identity":{"type":"string","minLength":1},
+          "capabilities":{"type":"array","minItems":1,"uniqueItems":true,"items":{"type":"string","minLength":1}},
+          "observed_at":{"type":"string","format":"date-time"},
+          "valid_until":{"type":"string","format":"date-time"}
+        },
+        "additionalProperties":true
+      }
+    },
+    "freshness_boundary": {
+      "type":"object",
+      "required":["observed_at","valid_until"],
+      "properties": {
+        "observed_at":{"type":"string","format":"date-time"},
+        "valid_until":{"type":"string","format":"date-time"}
+      },
+      "additionalProperties":false
+    },
     "limitations": {"type":"array","items":{"type":"string"}}
   },
   "additionalProperties": true

--- a/tests/test_executability.py
+++ b/tests/test_executability.py
@@ -1,21 +1,105 @@
 from __future__ import annotations
 
+from copy import deepcopy
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
 import unittest
 
 from tools.executability import (
     evaluate_assignment_admissibility,
     validate_admissibility_against_profile,
     validate_admissibility_record,
+    validate_assignment_execution_contract,
     validate_capability_profile,
 )
 
 
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def valid_chain() -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    profile = {
+        "artifact_type": "CAPABILITY_PROFILE",
+        "artifact_id": "CAP-1",
+        "produced_by_role": "control-director",
+        "assignment_id": None,
+        "input_state_ref": "state-1",
+        "status": "CURRENT",
+        "provenance": ["local-probe"],
+        "related_artifacts": ["EVIDENCE-1"],
+        "destination_id": "agent-1",
+        "runtime_identity": "runtime-1",
+        "available_capabilities": ["shell", "python_runtime"],
+        "unavailable_capabilities": ["outbound_network"],
+        "capability_evidence": [
+            {"capability": "shell", "evidence_ref": "EVIDENCE-1"},
+            {"capability": "python_runtime", "evidence_ref": "EVIDENCE-1"},
+        ],
+        "evidence_artifacts": [{
+            "artifact_type": "CAPABILITY_EVIDENCE",
+            "artifact_id": "EVIDENCE-1",
+            "status": "RESOLVED",
+            "runtime_identity": "runtime-1",
+            "capabilities": ["shell", "python_runtime"],
+            "observed_at": "2026-01-01T00:00:00Z",
+            "valid_until": "2999-01-01T00:00:00Z",
+        }],
+        "freshness_boundary": {
+            "observed_at": "2026-01-01T00:00:00Z",
+            "valid_until": "2999-01-01T00:00:00Z",
+        },
+        "limitations": [],
+    }
+    record = {
+        "artifact_type": "ASSIGNMENT_ADMISSIBILITY",
+        "artifact_id": "ADM-1",
+        "produced_by_role": "control-director",
+        "assignment_id": None,
+        "input_state_ref": "state-1",
+        "status": "ADMISSIBLE",
+        "provenance": ["CAP-1"],
+        "related_artifacts": ["CAP-1"],
+        "assignment_draft_id": "DRAFT-1",
+        "destination_id": "agent-1",
+        "runtime_identity": "runtime-1",
+        "capability_profile_ref": "CAP-1",
+        "mandatory_actions": [{
+            "action_id": "run_tests",
+            "required_capabilities": ["shell", "python_runtime"],
+            "evidence_path": "python -m unittest",
+        }],
+        "required_capabilities": ["shell", "python_runtime"],
+        "available_capabilities": ["shell", "python_runtime"],
+        "unsatisfied_required_capabilities": [],
+        "mandatory_evidence_paths": ["python -m unittest"],
+        "execution_mode": "local",
+    }
+    assignment = {
+        "artifact_type": "ASSIGNMENT",
+        "artifact_id": "ASSIGN-1",
+        "assignment_id": "ASSIGN-1",
+        "execution_contract": {
+            "assignment_draft_ref": "DRAFT-1",
+            "destination_id": "agent-1",
+            "runtime_identity": "runtime-1",
+            "capability_profile_ref": "CAP-1",
+            "admissibility_ref": "ADM-1",
+            "proof_status": "PROVEN",
+            "required_capabilities": ["shell", "python_runtime"],
+            "unsatisfied_required_capabilities": [],
+            "mandatory_evidence_paths": ["python -m unittest"],
+            "execution_mode": "local",
+        },
+    }
+    return assignment, record, profile
+
+
 class ExecutabilityContractTest(unittest.TestCase):
     def test_required_subset_available_is_admissible(self) -> None:
-        result = evaluate_assignment_admissibility(
-            ["repository_remote_read", "repository_remote_write"],
-            ["repository_remote_write", "repository_remote_read", "connector:github"],
-        )
+        result = evaluate_assignment_admissibility(["shell"], ["shell", "python_runtime"])
         self.assertEqual(result["status"], "ADMISSIBLE")
         self.assertEqual(result["unsatisfied_required_capabilities"], [])
 
@@ -25,101 +109,115 @@ class ExecutabilityContractTest(unittest.TestCase):
             ["repository_remote_read", "repository_remote_write", "connector:github"],
         )
         self.assertEqual(result["status"], "NOT_ADMISSIBLE")
-        self.assertEqual(
-            result["unsatisfied_required_capabilities"],
-            ["python_runtime", "repository_local_checkout", "shell"],
+        self.assertEqual(result["unsatisfied_required_capabilities"], ["python_runtime", "repository_local_checkout", "shell"])
+
+    def test_complete_chain_passes(self) -> None:
+        self.assertEqual(validate_assignment_execution_contract(*valid_chain()), [])
+
+    def assert_contract_rejected(self, assignment: dict[str, object], record: dict[str, object], profile: dict[str, object], fragment: str) -> None:
+        errors = validate_assignment_execution_contract(assignment, record, profile)
+        self.assertTrue(any(fragment in error for error in errors), msg=str(errors))
+
+    def test_assignment_chain_mismatches_rejected(self) -> None:
+        mutations = [
+            ("assignment_draft_ref", "UNRELATED", "assignment_draft_ref mismatch"),
+            ("admissibility_ref", "ADM-X", "admissibility_ref mismatch"),
+            ("capability_profile_ref", "CAP-X", "capability_profile_ref mismatch"),
+            ("destination_id", "agent-X", "assignment destination mismatch"),
+            ("runtime_identity", "runtime-X", "assignment runtime_identity mismatch"),
+            ("required_capabilities", ["shell"], "required_capabilities do not match"),
+            ("mandatory_evidence_paths", ["different"], "mandatory_evidence_paths do not match"),
+            ("execution_mode", "remote", "execution_mode does not match"),
+        ]
+        for field, value, fragment in mutations:
+            with self.subTest(field=field):
+                assignment, record, profile = deepcopy(valid_chain())
+                assignment["execution_contract"][field] = value  # type: ignore[index]
+                self.assert_contract_rejected(assignment, record, profile, fragment)
+
+    def test_missing_or_blank_draft_binding_rejected(self) -> None:
+        for value in [None, ""]:
+            assignment, record, profile = deepcopy(valid_chain())
+            if value is None:
+                del assignment["execution_contract"]["assignment_draft_ref"]  # type: ignore[index]
+            else:
+                assignment["execution_contract"]["assignment_draft_ref"] = value  # type: ignore[index]
+            self.assert_contract_rejected(assignment, record, profile, "assignment_draft_ref")
+
+    def test_non_admissible_and_nonempty_unsatisfied_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        record["status"] = "NOT_ADMISSIBLE"
+        record["available_capabilities"] = ["shell"]
+        record["unsatisfied_required_capabilities"] = ["python_runtime"]
+        profile["available_capabilities"] = ["shell"]
+        profile["capability_evidence"] = [{"capability": "shell", "evidence_ref": "EVIDENCE-1"}]
+        assignment["execution_contract"]["unsatisfied_required_capabilities"] = ["python_runtime"]  # type: ignore[index]
+        self.assert_contract_rejected(assignment, record, profile, "non-ADMISSIBLE")
+        self.assert_contract_rejected(assignment, record, profile, "unsatisfied required capabilities")
+
+    def test_profile_overlap_and_missing_evidence_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["unavailable_capabilities"] = ["shell"]
+        self.assert_contract_rejected(assignment, record, profile, "both available and unavailable")
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["capability_evidence"] = []
+        self.assert_contract_rejected(assignment, record, profile, "missing evidence")
+
+    def test_incomplete_profile_rejected(self) -> None:
+        for field in ["artifact_type", "produced_by_role", "status", "provenance", "related_artifacts", "runtime_identity", "freshness_boundary", "limitations"]:
+            with self.subTest(field=field):
+                assignment, record, profile = deepcopy(valid_chain())
+                del profile[field]
+                self.assertTrue(validate_assignment_execution_contract(assignment, record, profile))
+
+    def test_expired_profile_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["freshness_boundary"]["valid_until"] = "2000-01-01T00:00:00Z"  # type: ignore[index]
+        self.assert_contract_rejected(assignment, record, profile, "expired")
+
+    def test_unresolved_and_fake_evidence_rejected(self) -> None:
+        for evidence_ref in ["UNKNOWN-EVIDENCE", "fabricated"]:
+            assignment, record, profile = deepcopy(valid_chain())
+            profile["capability_evidence"][0]["evidence_ref"] = evidence_ref  # type: ignore[index]
+            self.assert_contract_rejected(assignment, record, profile, "unresolved")
+
+    def test_profile_admissibility_runtime_and_available_mismatch_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        record["runtime_identity"] = "runtime-X"
+        self.assert_contract_rejected(assignment, record, profile, "runtime identity mismatch")
+        assignment, record, profile = deepcopy(valid_chain())
+        record["available_capabilities"] = ["shell"]
+        self.assert_contract_rejected(assignment, record, profile, "do not match cited capability profile")
+
+    def test_record_requirement_derivation_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        record["mandatory_actions"][0]["required_capabilities"] = ["shell"]  # type: ignore[index]
+        self.assert_contract_rejected(assignment, record, profile, "union of mandatory action requirements")
+
+    def test_cli_requires_complete_arguments(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "tools/executability.py", "--assignment", "a.json"],
+            cwd=ROOT, text=True, capture_output=True, check=False,
         )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--assignment requires --record and --profile", result.stderr)
 
-    def test_playwright_is_not_browser_free_fallback(self) -> None:
-        result = evaluate_assignment_admissibility(
-            ["repository_local_checkout", "node_runtime", "package_install", "playwright_runtime"],
-            ["repository_remote_read", "repository_remote_write", "connector:github"],
-        )
-        self.assertEqual(result["status"], "NOT_ADMISSIBLE")
-        self.assertIn("playwright_runtime", result["unsatisfied_required_capabilities"])
-
-    def test_record_status_cannot_claim_admissible_with_missing_capability(self) -> None:
-        record = {
-            "status": "ADMISSIBLE",
-            "mandatory_actions": [
-                {
-                    "action_id": "run_local_validator",
-                    "required_capabilities": ["shell", "python_runtime"],
-                    "evidence_path": "python tools/validate_structure.py",
-                }
-            ],
-            "required_capabilities": ["shell", "python_runtime"],
-            "available_capabilities": ["python_runtime"],
-            "unsatisfied_required_capabilities": [],
-            "mandatory_evidence_paths": ["python tools/validate_structure.py"],
-        }
-        errors = validate_admissibility_record(record)
-        self.assertTrue(any("status drift" in error for error in errors), msg=str(errors))
-        self.assertTrue(any("unsatisfied_required_capabilities drift" in error for error in errors), msg=str(errors))
-
-    def test_record_cannot_underdeclare_mandatory_action_capabilities(self) -> None:
-        record = {
-            "status": "ADMISSIBLE",
-            "mandatory_actions": [
-                {
-                    "action_id": "run_tests",
-                    "required_capabilities": ["repository_local_checkout", "shell", "python_runtime"],
-                    "evidence_path": "python -m unittest",
-                }
-            ],
-            "required_capabilities": ["python_runtime"],
-            "available_capabilities": ["python_runtime"],
-            "unsatisfied_required_capabilities": [],
-            "mandatory_evidence_paths": ["python -m unittest"],
-        }
-        errors = validate_admissibility_record(record)
-        self.assertTrue(any("do not equal union" in error for error in errors), msg=str(errors))
-
-    def test_profile_requires_evidence_for_every_available_capability(self) -> None:
-        profile = {
-            "artifact_id": "CAP-1",
-            "destination_id": "agent-1",
-            "available_capabilities": ["repository_remote_read", "connector:github"],
-            "unavailable_capabilities": ["shell"],
-            "capability_evidence": [
-                {"capability": "repository_remote_read", "evidence_ref": "github-readback"}
-            ],
-        }
-        errors = validate_capability_profile(profile)
-        self.assertTrue(any("missing evidence" in error for error in errors), msg=str(errors))
-
-    def test_admissibility_is_bound_to_exact_profile(self) -> None:
-        profile = {
-            "artifact_id": "CAP-1",
-            "destination_id": "agent-1",
-            "available_capabilities": ["repository_remote_read", "connector:github"],
-            "unavailable_capabilities": ["shell"],
-            "capability_evidence": [
-                {"capability": "repository_remote_read", "evidence_ref": "github-readback"},
-                {"capability": "connector:github", "evidence_ref": "github-connector-discovery"},
-            ],
-        }
-        record = {
-            "status": "ADMISSIBLE",
-            "destination_id": "agent-1",
-            "capability_profile_ref": "CAP-1",
-            "mandatory_actions": [
-                {
-                    "action_id": "read_remote_state",
-                    "required_capabilities": ["repository_remote_read"],
-                    "evidence_path": "GitHub repository readback",
-                }
-            ],
-            "required_capabilities": ["repository_remote_read"],
-            "available_capabilities": ["repository_remote_read", "connector:github"],
-            "unsatisfied_required_capabilities": [],
-            "mandatory_evidence_paths": ["GitHub repository readback"],
-        }
-        self.assertEqual(validate_admissibility_against_profile(record, profile), [])
-
-        record["available_capabilities"] = ["repository_remote_read", "shell"]
-        errors = validate_admissibility_against_profile(record, profile)
-        self.assertTrue(any("do not match cited capability profile" in error for error in errors), msg=str(errors))
+    def test_cli_valid_and_invalid_complete_chain(self) -> None:
+        assignment, record, profile = valid_chain()
+        with tempfile.TemporaryDirectory() as directory:
+            paths = []
+            for name, value in [("assignment", assignment), ("record", record), ("profile", profile)]:
+                path = Path(directory) / f"{name}.json"
+                path.write_text(json.dumps(value), encoding="utf-8")
+                paths.append(path)
+            command = [sys.executable, "tools/executability.py", "--assignment", str(paths[0]), "--record", str(paths[1]), "--profile", str(paths[2])]
+            valid = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
+            self.assertEqual(valid.returncode, 0, valid.stdout + valid.stderr)
+            assignment["execution_contract"]["assignment_draft_ref"] = "UNRELATED"  # type: ignore[index]
+            paths[0].write_text(json.dumps(assignment), encoding="utf-8")
+            invalid = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
+            self.assertNotEqual(invalid.returncode, 0)
+            self.assertIn("assignment_draft_ref mismatch", invalid.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_executability.py
+++ b/tests/test_executability.py
@@ -80,7 +80,21 @@ def valid_chain() -> tuple[dict[str, object], dict[str, object], dict[str, objec
     assignment = {
         "artifact_type": "ASSIGNMENT",
         "artifact_id": "ASSIGN-1",
+        "produced_by_role": "control-director",
         "assignment_id": "ASSIGN-1",
+        "input_state_ref": "state-1",
+        "status": "ISSUED",
+        "provenance": ["ADM-1"],
+        "related_artifacts": ["ADM-1", "CAP-1"],
+        "objective": "Run the prescribed verification.",
+        "authority": ["OWNER/K0"],
+        "scope": {
+            "allowed": ["run prescribed verification"],
+            "forbidden": ["repair code"],
+        },
+        "acceptance": ["required verification evidence is produced"],
+        "stop_conditions": ["runtime drift invalidates the admitted execution route"],
+        "result_to": "control-layer",
         "execution_contract": {
             "assignment_draft_ref": "DRAFT-1",
             "destination_id": "agent-1",
@@ -109,12 +123,21 @@ class ExecutabilityContractTest(unittest.TestCase):
             ["repository_remote_read", "repository_remote_write", "connector:github"],
         )
         self.assertEqual(result["status"], "NOT_ADMISSIBLE")
-        self.assertEqual(result["unsatisfied_required_capabilities"], ["python_runtime", "repository_local_checkout", "shell"])
+        self.assertEqual(
+            result["unsatisfied_required_capabilities"],
+            ["python_runtime", "repository_local_checkout", "shell"],
+        )
 
     def test_complete_chain_passes(self) -> None:
         self.assertEqual(validate_assignment_execution_contract(*valid_chain()), [])
 
-    def assert_contract_rejected(self, assignment: dict[str, object], record: dict[str, object], profile: dict[str, object], fragment: str) -> None:
+    def assert_contract_rejected(
+        self,
+        assignment: dict[str, object],
+        record: dict[str, object],
+        profile: dict[str, object],
+        fragment: str,
+    ) -> None:
         errors = validate_assignment_execution_contract(assignment, record, profile)
         self.assertTrue(any(fragment in error for error in errors), msg=str(errors))
 
@@ -144,6 +167,26 @@ class ExecutabilityContractTest(unittest.TestCase):
                 assignment["execution_contract"]["assignment_draft_ref"] = value  # type: ignore[index]
             self.assert_contract_rejected(assignment, record, profile, "assignment_draft_ref")
 
+    def test_schema_required_assignment_surface_rejected_when_missing(self) -> None:
+        required_fields = [
+            "produced_by_role",
+            "input_state_ref",
+            "status",
+            "provenance",
+            "related_artifacts",
+            "objective",
+            "authority",
+            "scope",
+            "acceptance",
+            "stop_conditions",
+            "result_to",
+        ]
+        for field in required_fields:
+            with self.subTest(field=field):
+                assignment, record, profile = deepcopy(valid_chain())
+                del assignment[field]
+                self.assert_contract_rejected(assignment, record, profile, f"assignment.{field}")
+
     def test_non_admissible_and_nonempty_unsatisfied_rejected(self) -> None:
         assignment, record, profile = deepcopy(valid_chain())
         record["status"] = "NOT_ADMISSIBLE"
@@ -164,7 +207,18 @@ class ExecutabilityContractTest(unittest.TestCase):
         self.assert_contract_rejected(assignment, record, profile, "missing evidence")
 
     def test_incomplete_profile_rejected(self) -> None:
-        for field in ["artifact_type", "produced_by_role", "status", "provenance", "related_artifacts", "runtime_identity", "freshness_boundary", "limitations"]:
+        for field in [
+            "artifact_type",
+            "produced_by_role",
+            "assignment_id",
+            "input_state_ref",
+            "status",
+            "provenance",
+            "related_artifacts",
+            "runtime_identity",
+            "freshness_boundary",
+            "limitations",
+        ]:
             with self.subTest(field=field):
                 assignment, record, profile = deepcopy(valid_chain())
                 del profile[field]
@@ -175,11 +229,62 @@ class ExecutabilityContractTest(unittest.TestCase):
         profile["freshness_boundary"]["valid_until"] = "2000-01-01T00:00:00Z"  # type: ignore[index]
         self.assert_contract_rejected(assignment, record, profile, "expired")
 
+    def test_evidence_beginning_after_profile_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["evidence_artifacts"][0]["observed_at"] = "2026-01-01T00:00:01Z"  # type: ignore[index]
+        self.assert_contract_rejected(
+            assignment,
+            record,
+            profile,
+            "begins after the profile freshness boundary",
+        )
+
+    def test_future_evidence_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["evidence_artifacts"][0]["observed_at"] = "2998-01-01T00:00:00Z"  # type: ignore[index]
+        self.assert_contract_rejected(assignment, record, profile, "starts in the future")
+
     def test_unresolved_and_fake_evidence_rejected(self) -> None:
         for evidence_ref in ["UNKNOWN-EVIDENCE", "fabricated"]:
             assignment, record, profile = deepcopy(valid_chain())
             profile["capability_evidence"][0]["evidence_ref"] = evidence_ref  # type: ignore[index]
             self.assert_contract_rejected(assignment, record, profile, "unresolved")
+
+    def test_unreferenced_invalid_evidence_artifact_rejected(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["evidence_artifacts"].append({"artifact_id": "BROKEN"})  # type: ignore[union-attr]
+        self.assert_contract_rejected(
+            assignment,
+            record,
+            profile,
+            "evidence_artifacts[1].artifact_type",
+        )
+
+    def test_schema_unique_capability_lists_rejected_when_duplicated(self) -> None:
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["available_capabilities"] = ["shell", "shell", "python_runtime"]
+        self.assert_contract_rejected(
+            assignment,
+            record,
+            profile,
+            "available_capabilities must not contain duplicates",
+        )
+        assignment, record, profile = deepcopy(valid_chain())
+        profile["evidence_artifacts"][0]["capabilities"] = ["shell", "shell", "python_runtime"]  # type: ignore[index]
+        self.assert_contract_rejected(
+            assignment,
+            record,
+            profile,
+            "evidence_artifacts[0].capabilities must not contain duplicates",
+        )
+        assignment, record, profile = deepcopy(valid_chain())
+        record["required_capabilities"] = ["shell", "shell", "python_runtime"]
+        self.assert_contract_rejected(
+            assignment,
+            record,
+            profile,
+            "required_capabilities must not contain duplicates",
+        )
 
     def test_profile_admissibility_runtime_and_available_mismatch_rejected(self) -> None:
         assignment, record, profile = deepcopy(valid_chain())
@@ -187,17 +292,30 @@ class ExecutabilityContractTest(unittest.TestCase):
         self.assert_contract_rejected(assignment, record, profile, "runtime identity mismatch")
         assignment, record, profile = deepcopy(valid_chain())
         record["available_capabilities"] = ["shell"]
-        self.assert_contract_rejected(assignment, record, profile, "do not match cited capability profile")
+        self.assert_contract_rejected(
+            assignment,
+            record,
+            profile,
+            "do not match cited capability profile",
+        )
 
     def test_record_requirement_derivation_rejected(self) -> None:
         assignment, record, profile = deepcopy(valid_chain())
         record["mandatory_actions"][0]["required_capabilities"] = ["shell"]  # type: ignore[index]
-        self.assert_contract_rejected(assignment, record, profile, "union of mandatory action requirements")
+        self.assert_contract_rejected(
+            assignment,
+            record,
+            profile,
+            "union of mandatory action requirements",
+        )
 
     def test_cli_requires_complete_arguments(self) -> None:
         result = subprocess.run(
             [sys.executable, "tools/executability.py", "--assignment", "a.json"],
-            cwd=ROOT, text=True, capture_output=True, check=False,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("--assignment requires --record and --profile", result.stderr)
@@ -206,18 +324,57 @@ class ExecutabilityContractTest(unittest.TestCase):
         assignment, record, profile = valid_chain()
         with tempfile.TemporaryDirectory() as directory:
             paths = []
-            for name, value in [("assignment", assignment), ("record", record), ("profile", profile)]:
+            for name, value in [
+                ("assignment", assignment),
+                ("record", record),
+                ("profile", profile),
+            ]:
                 path = Path(directory) / f"{name}.json"
                 path.write_text(json.dumps(value), encoding="utf-8")
                 paths.append(path)
-            command = [sys.executable, "tools/executability.py", "--assignment", str(paths[0]), "--record", str(paths[1]), "--profile", str(paths[2])]
-            valid = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
+            command = [
+                sys.executable,
+                "tools/executability.py",
+                "--assignment",
+                str(paths[0]),
+                "--record",
+                str(paths[1]),
+                "--profile",
+                str(paths[2]),
+            ]
+            valid = subprocess.run(
+                command,
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
             self.assertEqual(valid.returncode, 0, valid.stdout + valid.stderr)
+
+            invalid_assignment = deepcopy(assignment)
+            del invalid_assignment["objective"]
+            paths[0].write_text(json.dumps(invalid_assignment), encoding="utf-8")
+            invalid_schema = subprocess.run(
+                command,
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(invalid_schema.returncode, 0)
+            self.assertIn("assignment.objective", invalid_schema.stdout)
+
             assignment["execution_contract"]["assignment_draft_ref"] = "UNRELATED"  # type: ignore[index]
             paths[0].write_text(json.dumps(assignment), encoding="utf-8")
-            invalid = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
-            self.assertNotEqual(invalid.returncode, 0)
-            self.assertIn("assignment_draft_ref mismatch", invalid.stdout)
+            invalid_binding = subprocess.run(
+                command,
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(invalid_binding.returncode, 0)
+            self.assertIn("assignment_draft_ref mismatch", invalid_binding.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_executability_structure.py
+++ b/tests/test_executability_structure.py
@@ -15,7 +15,9 @@ class ExecutabilityStructureTest(unittest.TestCase):
         self.assertEqual(contract["properties"]["proof_status"]["const"], "PROVEN")
         self.assertEqual(contract["properties"]["unsatisfied_required_capabilities"]["maxItems"], 0)
         for required in [
+            "assignment_draft_ref",
             "destination_id",
+            "runtime_identity",
             "capability_profile_ref",
             "admissibility_ref",
             "required_capabilities",
@@ -30,11 +32,16 @@ class ExecutabilityStructureTest(unittest.TestCase):
         self.assertIn("available_capabilities", schema["required"])
         self.assertIn("unavailable_capabilities", schema["required"])
         self.assertIn("freshness_boundary", schema["required"])
+        self.assertIn("evidence_artifacts", schema["required"])
+        boundary = schema["properties"]["freshness_boundary"]
+        self.assertEqual(boundary["type"], "object")
+        self.assertEqual(boundary["required"], ["observed_at", "valid_until"])
 
     def test_admissibility_schema_fails_closed(self) -> None:
         schema = json.loads((ROOT / "schemas/assignment-admissibility.schema.json").read_text(encoding="utf-8"))
         self.assertEqual(schema["properties"]["status"]["enum"], ["ADMISSIBLE", "NOT_ADMISSIBLE"])
         self.assertIn("mandatory_actions", schema["required"])
+        self.assertIn("runtime_identity", schema["required"])
         self.assertEqual(schema["properties"]["mandatory_actions"]["minItems"], 1)
         serialized = json.dumps(schema)
         self.assertIn('"maxItems": 0', serialized)

--- a/tools/executability.py
+++ b/tools/executability.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 
@@ -15,6 +16,12 @@ def _timestamp(value: object, field: str, errors: list[str]) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         errors.append(f"{field} must be a non-empty ISO-8601 timestamp")
         return None
+    if re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})",
+        value,
+    ) is None:
+        errors.append(f"{field} must be an RFC3339 date-time")
+        return None
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
@@ -24,6 +31,29 @@ def _timestamp(value: object, field: str, errors: list[str]) -> datetime | None:
         errors.append(f"{field} must include a timezone")
         return None
     return parsed.astimezone(timezone.utc)
+
+
+def _string_list(
+    value: object,
+    field: str,
+    errors: list[str],
+    *,
+    unique: bool = False,
+    min_items: int = 0,
+    non_empty: bool = True,
+) -> list[str] | None:
+    if not isinstance(value, list):
+        errors.append(f"{field} must be a list")
+        return None
+    if len(value) < min_items:
+        errors.append(f"{field} must contain at least {min_items} item(s)")
+    if not all(isinstance(item, str) and (item.strip() if non_empty else True) for item in value):
+        errors.append(f"{field} must be a list of {'non-empty ' if non_empty else ''}strings")
+        return None
+    normalized = [item.strip() if non_empty else item for item in value]
+    if unique and len(set(normalized)) != len(normalized):
+        errors.append(f"{field} must not contain duplicates")
+    return normalized
 
 
 def evaluate_assignment_admissibility(
@@ -43,21 +73,21 @@ def evaluate_assignment_admissibility(
 
 
 def validate_capability_profile(profile: Mapping[str, object]) -> list[str]:
-    """Validate internal consistency and evidence coverage for a CAPABILITY_PROFILE."""
+    """Validate internal consistency, freshness, runtime binding, and evidence coverage."""
     errors: list[str] = []
-    required_strings = ["artifact_id", "produced_by_role", "status", "destination_id", "runtime_identity"]
     if profile.get("artifact_type") != "CAPABILITY_PROFILE":
         errors.append("artifact_type must be CAPABILITY_PROFILE")
     if profile.get("status") != "CURRENT":
         errors.append("capability profile status must be CURRENT")
-    for field in required_strings:
+    for field in ["artifact_id", "produced_by_role", "status", "destination_id", "runtime_identity"]:
         if not isinstance(profile.get(field), str) or not str(profile[field]).strip():
             errors.append(f"{field} must be a non-empty string")
     for field in ["provenance", "related_artifacts", "limitations"]:
-        value = profile.get(field)
-        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-            errors.append(f"{field} must be a list of strings")
+        _string_list(profile.get(field), field, errors, non_empty=False)
     for field in ["assignment_id", "input_state_ref"]:
+        if field not in profile:
+            errors.append(f"{field} is required")
+            continue
         value = profile.get(field)
         if value is not None and (not isinstance(value, str) or not value.strip()):
             errors.append(f"{field} must be null or a non-empty string")
@@ -67,49 +97,91 @@ def validate_capability_profile(profile: Mapping[str, object]) -> list[str]:
         errors.append("freshness_boundary must be an object")
         observed_at = valid_until = None
     else:
+        extra_boundary_fields = sorted(set(boundary) - {"observed_at", "valid_until"})
+        if extra_boundary_fields:
+            errors.append(f"freshness_boundary has unexpected fields: {extra_boundary_fields}")
         observed_at = _timestamp(boundary.get("observed_at"), "freshness_boundary.observed_at", errors)
         valid_until = _timestamp(boundary.get("valid_until"), "freshness_boundary.valid_until", errors)
         if observed_at and valid_until and observed_at > valid_until:
             errors.append("freshness_boundary observed_at must not be after valid_until")
-        if observed_at and observed_at > datetime.now(timezone.utc):
+        now = datetime.now(timezone.utc)
+        if observed_at and observed_at > now:
             errors.append("capability profile freshness boundary starts in the future")
-        if valid_until and valid_until <= datetime.now(timezone.utc):
+        if valid_until and valid_until <= now:
             errors.append("capability profile freshness boundary is expired")
 
-    available = profile.get("available_capabilities")
-    unavailable = profile.get("unavailable_capabilities")
+    available = _string_list(
+        profile.get("available_capabilities"),
+        "available_capabilities",
+        errors,
+        unique=True,
+    )
+    unavailable = _string_list(
+        profile.get("unavailable_capabilities"),
+        "unavailable_capabilities",
+        errors,
+        unique=True,
+    )
     evidence = profile.get("capability_evidence")
-
-    if not isinstance(available, list) or not all(isinstance(v, str) and v.strip() for v in available):
-        return ["available_capabilities must be a list of non-empty strings"]
-    if not isinstance(unavailable, list) or not all(isinstance(v, str) and v.strip() for v in unavailable):
-        return ["unavailable_capabilities must be a list of non-empty strings"]
     if not isinstance(evidence, list):
-        return ["capability_evidence must be a list"]
+        errors.append("capability_evidence must be a list")
+        evidence = []
 
-    normalized_available = _normalize(available)
-    normalized_unavailable = _normalize(unavailable)
+    normalized_available = _normalize(available or [])
+    normalized_unavailable = _normalize(unavailable or [])
     overlap = sorted(set(normalized_available) & set(normalized_unavailable))
     if overlap:
         errors.append(f"capabilities cannot be both available and unavailable: {overlap}")
 
     runtime_identity = profile.get("runtime_identity")
+    related_artifacts = profile.get("related_artifacts")
     evidence_artifacts = profile.get("evidence_artifacts")
     if not isinstance(evidence_artifacts, list):
         errors.append("evidence_artifacts must be a list")
         evidence_artifacts = []
+
     evidence_by_id: dict[str, Mapping[str, object]] = {}
+    now = datetime.now(timezone.utc)
     for index, artifact in enumerate(evidence_artifacts):
+        prefix = f"evidence_artifacts[{index}]"
         if not isinstance(artifact, Mapping):
-            errors.append(f"evidence_artifacts[{index}] must be an object")
+            errors.append(f"{prefix} must be an object")
             continue
         artifact_id = artifact.get("artifact_id")
+        if artifact.get("artifact_type") != "CAPABILITY_EVIDENCE":
+            errors.append(f"{prefix}.artifact_type must be CAPABILITY_EVIDENCE")
         if not isinstance(artifact_id, str) or not artifact_id.strip():
-            errors.append(f"evidence_artifacts[{index}].artifact_id must be a non-empty string")
-            continue
-        if artifact_id in evidence_by_id:
+            errors.append(f"{prefix}.artifact_id must be a non-empty string")
+            artifact_id = None
+        elif artifact_id in evidence_by_id:
             errors.append(f"duplicate evidence artifact id: {artifact_id}")
-        evidence_by_id[artifact_id] = artifact
+        if artifact.get("status") != "RESOLVED":
+            errors.append(f"{prefix}.status must be RESOLVED")
+        if not isinstance(artifact.get("runtime_identity"), str) or not str(artifact["runtime_identity"]).strip():
+            errors.append(f"{prefix}.runtime_identity must be a non-empty string")
+        elif artifact.get("runtime_identity") != runtime_identity:
+            errors.append(f"{prefix}.runtime_identity mismatch")
+        _string_list(
+            artifact.get("capabilities"),
+            f"{prefix}.capabilities",
+            errors,
+            unique=True,
+            min_items=1,
+        )
+        evidence_observed = _timestamp(artifact.get("observed_at"), f"{prefix}.observed_at", errors)
+        evidence_valid = _timestamp(artifact.get("valid_until"), f"{prefix}.valid_until", errors)
+        if evidence_observed and evidence_observed > now:
+            errors.append(f"{prefix}.observed_at starts in the future")
+        if evidence_valid and evidence_valid <= now:
+            errors.append(f"{prefix}.valid_until is expired")
+        if evidence_observed and evidence_valid and evidence_observed > evidence_valid:
+            errors.append(f"{prefix}.observed_at is after valid_until")
+        if observed_at and evidence_observed and evidence_observed > observed_at:
+            errors.append(f"{prefix} begins after the profile freshness boundary")
+        if valid_until and evidence_valid and evidence_valid < valid_until:
+            errors.append(f"{prefix} expires before the profile")
+        if artifact_id:
+            evidence_by_id[artifact_id] = artifact
 
     evidence_caps: list[str] = []
     for index, item in enumerate(evidence):
@@ -128,32 +200,10 @@ def validate_capability_profile(profile: Mapping[str, object]) -> list[str]:
         if artifact is None:
             errors.append(f"capability_evidence[{index}].evidence_ref is unresolved: {evidence_ref!r}")
             continue
-        if artifact.get("artifact_type") != "CAPABILITY_EVIDENCE":
-            errors.append(f"evidence artifact {evidence_ref!r} has invalid artifact_type")
-        if artifact.get("status") != "RESOLVED":
-            errors.append(f"evidence artifact {evidence_ref!r} is not RESOLVED")
-        if artifact.get("runtime_identity") != runtime_identity:
-            errors.append(f"evidence artifact {evidence_ref!r} runtime_identity mismatch")
         capabilities = artifact.get("capabilities")
         if not isinstance(capabilities, list) or capability.strip() not in _normalize(capabilities):
             errors.append(f"evidence artifact {evidence_ref!r} does not prove {capability.strip()!r}")
-        evidence_observed = _timestamp(
-            artifact.get("observed_at"), f"evidence artifact {evidence_ref!r}.observed_at", errors
-        )
-        evidence_valid = _timestamp(
-            artifact.get("valid_until"), f"evidence artifact {evidence_ref!r}.valid_until", errors
-        )
-        if evidence_valid and evidence_valid <= datetime.now(timezone.utc):
-            errors.append(f"evidence artifact {evidence_ref!r} is expired")
-        if evidence_observed and evidence_valid and evidence_observed > evidence_valid:
-            errors.append(f"evidence artifact {evidence_ref!r} observed_at is after valid_until")
-        if observed_at and evidence_observed and evidence_observed < observed_at:
-            errors.append(f"evidence artifact {evidence_ref!r} predates the profile freshness boundary")
-        if valid_until and evidence_valid and evidence_valid < valid_until:
-            errors.append(f"evidence artifact {evidence_ref!r} expires before the profile")
         evidence_caps.append(capability.strip())
-
-        related_artifacts = profile.get("related_artifacts")
         if isinstance(related_artifacts, list) and evidence_ref not in related_artifacts:
             errors.append(f"evidence artifact {evidence_ref!r} is absent from related_artifacts")
 
@@ -180,28 +230,41 @@ def validate_admissibility_record(record: Mapping[str, object]) -> list[str]:
 
     if record.get("artifact_type") != "ASSIGNMENT_ADMISSIBILITY":
         errors.append("artifact_type must be ASSIGNMENT_ADMISSIBILITY")
-    for field in ["artifact_id", "produced_by_role", "assignment_draft_id", "destination_id", "runtime_identity", "capability_profile_ref", "execution_mode"]:
+    for field in [
+        "artifact_id",
+        "produced_by_role",
+        "assignment_draft_id",
+        "destination_id",
+        "runtime_identity",
+        "capability_profile_ref",
+        "execution_mode",
+    ]:
         if not isinstance(record.get(field), str) or not str(record[field]).strip():
             errors.append(f"{field} must be a non-empty string")
     for field in ["provenance", "related_artifacts"]:
-        value = record.get(field)
-        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-            errors.append(f"{field} must be a list of strings")
+        _string_list(record.get(field), field, errors, non_empty=False)
     for field in ["assignment_id", "input_state_ref"]:
+        if field not in record:
+            errors.append(f"{field} is required")
+            continue
         value = record.get(field)
         if value is not None and (not isinstance(value, str) or not value.strip()):
             errors.append(f"{field} must be null or a non-empty string")
+    for field in ["fallback_mode", "reason"]:
+        if field in record and record.get(field) is not None and not isinstance(record.get(field), str):
+            errors.append(f"{field} must be null or a string")
 
-    if not isinstance(required, list) or not all(isinstance(v, str) and v.strip() for v in required):
-        return ["required_capabilities must be a list of non-empty strings"]
-    if not isinstance(available, list) or not all(isinstance(v, str) and v.strip() for v in available):
-        return ["available_capabilities must be a list of non-empty strings"]
-    if not isinstance(missing, list) or not all(isinstance(v, str) and v.strip() for v in missing):
-        return ["unsatisfied_required_capabilities must be a list of non-empty strings"]
+    required_list = _string_list(required, "required_capabilities", errors, unique=True)
+    available_list = _string_list(available, "available_capabilities", errors, unique=True)
+    missing_list = _string_list(missing, "unsatisfied_required_capabilities", errors, unique=True)
     if not isinstance(actions, list) or not actions:
-        return ["mandatory_actions must be a non-empty list"]
-    if not isinstance(evidence_paths, list) or not all(isinstance(v, str) and v.strip() for v in evidence_paths):
-        return ["mandatory_evidence_paths must be a list of non-empty strings"]
+        errors.append("mandatory_actions must be a non-empty list")
+        actions = []
+    evidence_paths_list = _string_list(
+        evidence_paths,
+        "mandatory_evidence_paths",
+        errors,
+    )
 
     derived_required: set[str] = set()
     derived_evidence_paths: set[str] = set()
@@ -219,40 +282,43 @@ def validate_admissibility_record(record: Mapping[str, object]) -> list[str]:
             errors.append(f"duplicate mandatory action id: {action_id}")
         else:
             seen_action_ids.add(action_id)
-        if not isinstance(action_required, list) or not all(
-            isinstance(v, str) and v.strip() for v in action_required
-        ):
-            errors.append(f"mandatory_actions[{index}].required_capabilities must be a list of strings")
-        else:
-            derived_required.update(_normalize(action_required))
+        action_required_list = _string_list(
+            action_required,
+            f"mandatory_actions[{index}].required_capabilities",
+            errors,
+            unique=True,
+        )
+        if action_required_list is not None:
+            derived_required.update(_normalize(action_required_list))
         if evidence_path is not None:
             if not isinstance(evidence_path, str) or not evidence_path.strip():
                 errors.append(f"mandatory_actions[{index}].evidence_path must be null or a non-empty string")
             else:
                 derived_evidence_paths.add(evidence_path.strip())
 
-    normalized_required = _normalize(required)
+    normalized_required = _normalize(required_list or [])
     if sorted(derived_required) != normalized_required:
         errors.append(
             "required_capabilities do not equal union of mandatory action requirements: "
             f"derived {sorted(derived_required)}, declared {normalized_required}"
         )
 
-    normalized_paths = _normalize(evidence_paths)
+    normalized_paths = _normalize(evidence_paths_list or [])
     if sorted(derived_evidence_paths) != normalized_paths:
         errors.append(
             "mandatory_evidence_paths do not equal action evidence paths: "
             f"derived {sorted(derived_evidence_paths)}, declared {normalized_paths}"
         )
 
-    expected = evaluate_assignment_admissibility(required, available)
-    if status != expected["status"]:
-        errors.append(f"status drift: expected {expected['status']}, got {status}")
-    if _normalize(missing) != expected["unsatisfied_required_capabilities"]:
-        errors.append(
-            "unsatisfied_required_capabilities drift: "
-            f"expected {expected['unsatisfied_required_capabilities']}, got {_normalize(missing)}"
-        )
+    if required_list is not None and available_list is not None and missing_list is not None:
+        expected = evaluate_assignment_admissibility(required_list, available_list)
+        if status != expected["status"]:
+            errors.append(f"status drift: expected {expected['status']}, got {status}")
+        if _normalize(missing_list) != expected["unsatisfied_required_capabilities"]:
+            errors.append(
+                "unsatisfied_required_capabilities drift: "
+                f"expected {expected['unsatisfied_required_capabilities']}, got {_normalize(missing_list)}"
+            )
     return errors
 
 
@@ -297,16 +363,104 @@ def validate_admissibility_against_profile(
     return errors
 
 
+def validate_assignment_artifact(assignment: Mapping[str, object]) -> list[str]:
+    """Validate the schema-required ASSIGNMENT surface used by the complete-chain CLI."""
+    errors: list[str] = []
+    if assignment.get("artifact_type") != "ASSIGNMENT":
+        errors.append("assignment artifact_type must be ASSIGNMENT")
+    for field in [
+        "artifact_id",
+        "produced_by_role",
+        "assignment_id",
+        "status",
+        "objective",
+        "result_to",
+    ]:
+        if not isinstance(assignment.get(field), str) or not str(assignment[field]).strip():
+            errors.append(f"assignment.{field} must be a non-empty string")
+    if "input_state_ref" not in assignment:
+        errors.append("assignment.input_state_ref is required")
+    else:
+        input_state_ref = assignment.get("input_state_ref")
+        if input_state_ref is not None and (
+            not isinstance(input_state_ref, str) or not input_state_ref.strip()
+        ):
+            errors.append("assignment.input_state_ref must be null or a non-empty string")
+    for field in ["provenance", "related_artifacts", "acceptance", "stop_conditions"]:
+        _string_list(assignment.get(field), f"assignment.{field}", errors, non_empty=False)
+    _string_list(
+        assignment.get("authority"),
+        "assignment.authority",
+        errors,
+        min_items=1,
+        non_empty=False,
+    )
+    required_outputs = assignment.get("required_outputs")
+    if required_outputs is not None:
+        _string_list(required_outputs, "assignment.required_outputs", errors, non_empty=False)
+
+    scope = assignment.get("scope")
+    if not isinstance(scope, Mapping):
+        errors.append("assignment.scope must be an object")
+    else:
+        _string_list(scope.get("allowed"), "assignment.scope.allowed", errors, non_empty=False)
+        _string_list(scope.get("forbidden"), "assignment.scope.forbidden", errors, non_empty=False)
+
+    contract = assignment.get("execution_contract")
+    if not isinstance(contract, Mapping):
+        errors.append("assignment.execution_contract must be an object")
+        return errors
+
+    for field in [
+        "assignment_draft_ref",
+        "destination_id",
+        "runtime_identity",
+        "capability_profile_ref",
+        "admissibility_ref",
+        "execution_mode",
+    ]:
+        if not isinstance(contract.get(field), str) or not str(contract[field]).strip():
+            errors.append(f"assignment.execution_contract.{field} must be a non-empty string")
+    if contract.get("proof_status") != "PROVEN":
+        errors.append("assignment execution proof_status must be PROVEN")
+    _string_list(
+        contract.get("required_capabilities"),
+        "assignment.execution_contract.required_capabilities",
+        errors,
+        unique=True,
+    )
+    unsatisfied = _string_list(
+        contract.get("unsatisfied_required_capabilities"),
+        "assignment.execution_contract.unsatisfied_required_capabilities",
+        errors,
+        unique=True,
+    )
+    if unsatisfied:
+        errors.append("assignment.execution_contract.unsatisfied_required_capabilities must be empty")
+    _string_list(
+        contract.get("mandatory_evidence_paths"),
+        "assignment.execution_contract.mandatory_evidence_paths",
+        errors,
+    )
+    fallback = contract.get("fallback_mode")
+    if fallback is not None and not isinstance(fallback, str):
+        errors.append("assignment.execution_contract.fallback_mode must be null or a string")
+    return errors
+
+
 def validate_assignment_execution_contract(
     assignment: Mapping[str, object],
     record: Mapping[str, object],
     profile: Mapping[str, object],
 ) -> list[str]:
     """Validate the complete executable-assignment proof chain."""
-    errors = validate_admissibility_against_profile(record, profile)
+    errors = (
+        validate_admissibility_against_profile(record, profile)
+        + validate_assignment_artifact(assignment)
+    )
     contract = assignment.get("execution_contract")
     if not isinstance(contract, Mapping):
-        return errors + ["assignment.execution_contract must be an object"]
+        return errors
 
     if record.get("status") != "ADMISSIBLE":
         errors.append("executable assignment cites a non-ADMISSIBLE record")
@@ -362,9 +516,7 @@ def validate_assignment_execution_contract(
     assignment_missing = contract.get("unsatisfied_required_capabilities")
     if isinstance(record_missing, list) and isinstance(assignment_missing, list):
         if _normalize(record_missing) != _normalize(assignment_missing):
-            errors.append(
-                "assignment unsatisfied_required_capabilities do not match admissibility record"
-            )
+            errors.append("assignment unsatisfied_required_capabilities do not match admissibility record")
         if _normalize(assignment_missing):
             errors.append("executable assignment contains unsatisfied required capabilities")
     else:

--- a/tools/executability.py
+++ b/tools/executability.py
@@ -4,10 +4,26 @@ from __future__ import annotations
 import argparse
 import json
 from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
 
 
 def _normalize(values: Iterable[str]) -> list[str]:
     return sorted({value.strip() for value in values if isinstance(value, str) and value.strip()})
+
+
+def _timestamp(value: object, field: str, errors: list[str]) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{field} must be a non-empty ISO-8601 timestamp")
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        errors.append(f"{field} must be an ISO-8601 timestamp")
+        return None
+    if parsed.tzinfo is None:
+        errors.append(f"{field} must include a timezone")
+        return None
+    return parsed.astimezone(timezone.utc)
 
 
 def evaluate_assignment_admissibility(
@@ -29,6 +45,37 @@ def evaluate_assignment_admissibility(
 def validate_capability_profile(profile: Mapping[str, object]) -> list[str]:
     """Validate internal consistency and evidence coverage for a CAPABILITY_PROFILE."""
     errors: list[str] = []
+    required_strings = ["artifact_id", "produced_by_role", "status", "destination_id", "runtime_identity"]
+    if profile.get("artifact_type") != "CAPABILITY_PROFILE":
+        errors.append("artifact_type must be CAPABILITY_PROFILE")
+    if profile.get("status") != "CURRENT":
+        errors.append("capability profile status must be CURRENT")
+    for field in required_strings:
+        if not isinstance(profile.get(field), str) or not str(profile[field]).strip():
+            errors.append(f"{field} must be a non-empty string")
+    for field in ["provenance", "related_artifacts", "limitations"]:
+        value = profile.get(field)
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            errors.append(f"{field} must be a list of strings")
+    for field in ["assignment_id", "input_state_ref"]:
+        value = profile.get(field)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            errors.append(f"{field} must be null or a non-empty string")
+
+    boundary = profile.get("freshness_boundary")
+    if not isinstance(boundary, Mapping):
+        errors.append("freshness_boundary must be an object")
+        observed_at = valid_until = None
+    else:
+        observed_at = _timestamp(boundary.get("observed_at"), "freshness_boundary.observed_at", errors)
+        valid_until = _timestamp(boundary.get("valid_until"), "freshness_boundary.valid_until", errors)
+        if observed_at and valid_until and observed_at > valid_until:
+            errors.append("freshness_boundary observed_at must not be after valid_until")
+        if observed_at and observed_at > datetime.now(timezone.utc):
+            errors.append("capability profile freshness boundary starts in the future")
+        if valid_until and valid_until <= datetime.now(timezone.utc):
+            errors.append("capability profile freshness boundary is expired")
+
     available = profile.get("available_capabilities")
     unavailable = profile.get("unavailable_capabilities")
     evidence = profile.get("capability_evidence")
@@ -46,6 +93,24 @@ def validate_capability_profile(profile: Mapping[str, object]) -> list[str]:
     if overlap:
         errors.append(f"capabilities cannot be both available and unavailable: {overlap}")
 
+    runtime_identity = profile.get("runtime_identity")
+    evidence_artifacts = profile.get("evidence_artifacts")
+    if not isinstance(evidence_artifacts, list):
+        errors.append("evidence_artifacts must be a list")
+        evidence_artifacts = []
+    evidence_by_id: dict[str, Mapping[str, object]] = {}
+    for index, artifact in enumerate(evidence_artifacts):
+        if not isinstance(artifact, Mapping):
+            errors.append(f"evidence_artifacts[{index}] must be an object")
+            continue
+        artifact_id = artifact.get("artifact_id")
+        if not isinstance(artifact_id, str) or not artifact_id.strip():
+            errors.append(f"evidence_artifacts[{index}].artifact_id must be a non-empty string")
+            continue
+        if artifact_id in evidence_by_id:
+            errors.append(f"duplicate evidence artifact id: {artifact_id}")
+        evidence_by_id[artifact_id] = artifact
+
     evidence_caps: list[str] = []
     for index, item in enumerate(evidence):
         if not isinstance(item, Mapping):
@@ -59,7 +124,38 @@ def validate_capability_profile(profile: Mapping[str, object]) -> list[str]:
         if not isinstance(evidence_ref, str) or not evidence_ref.strip():
             errors.append(f"capability_evidence[{index}].evidence_ref must be a non-empty string")
             continue
+        artifact = evidence_by_id.get(evidence_ref)
+        if artifact is None:
+            errors.append(f"capability_evidence[{index}].evidence_ref is unresolved: {evidence_ref!r}")
+            continue
+        if artifact.get("artifact_type") != "CAPABILITY_EVIDENCE":
+            errors.append(f"evidence artifact {evidence_ref!r} has invalid artifact_type")
+        if artifact.get("status") != "RESOLVED":
+            errors.append(f"evidence artifact {evidence_ref!r} is not RESOLVED")
+        if artifact.get("runtime_identity") != runtime_identity:
+            errors.append(f"evidence artifact {evidence_ref!r} runtime_identity mismatch")
+        capabilities = artifact.get("capabilities")
+        if not isinstance(capabilities, list) or capability.strip() not in _normalize(capabilities):
+            errors.append(f"evidence artifact {evidence_ref!r} does not prove {capability.strip()!r}")
+        evidence_observed = _timestamp(
+            artifact.get("observed_at"), f"evidence artifact {evidence_ref!r}.observed_at", errors
+        )
+        evidence_valid = _timestamp(
+            artifact.get("valid_until"), f"evidence artifact {evidence_ref!r}.valid_until", errors
+        )
+        if evidence_valid and evidence_valid <= datetime.now(timezone.utc):
+            errors.append(f"evidence artifact {evidence_ref!r} is expired")
+        if evidence_observed and evidence_valid and evidence_observed > evidence_valid:
+            errors.append(f"evidence artifact {evidence_ref!r} observed_at is after valid_until")
+        if observed_at and evidence_observed and evidence_observed < observed_at:
+            errors.append(f"evidence artifact {evidence_ref!r} predates the profile freshness boundary")
+        if valid_until and evidence_valid and evidence_valid < valid_until:
+            errors.append(f"evidence artifact {evidence_ref!r} expires before the profile")
         evidence_caps.append(capability.strip())
+
+        related_artifacts = profile.get("related_artifacts")
+        if isinstance(related_artifacts, list) and evidence_ref not in related_artifacts:
+            errors.append(f"evidence artifact {evidence_ref!r} is absent from related_artifacts")
 
     missing_evidence = sorted(set(normalized_available) - set(evidence_caps))
     if missing_evidence:
@@ -81,6 +177,20 @@ def validate_admissibility_record(record: Mapping[str, object]) -> list[str]:
     actions = record.get("mandatory_actions")
     evidence_paths = record.get("mandatory_evidence_paths")
     status = record.get("status")
+
+    if record.get("artifact_type") != "ASSIGNMENT_ADMISSIBILITY":
+        errors.append("artifact_type must be ASSIGNMENT_ADMISSIBILITY")
+    for field in ["artifact_id", "produced_by_role", "assignment_draft_id", "destination_id", "runtime_identity", "capability_profile_ref", "execution_mode"]:
+        if not isinstance(record.get(field), str) or not str(record[field]).strip():
+            errors.append(f"{field} must be a non-empty string")
+    for field in ["provenance", "related_artifacts"]:
+        value = record.get(field)
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            errors.append(f"{field} must be a list of strings")
+    for field in ["assignment_id", "input_state_ref"]:
+        value = record.get(field)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            errors.append(f"{field} must be null or a non-empty string")
 
     if not isinstance(required, list) or not all(isinstance(v, str) and v.strip() for v in required):
         return ["required_capabilities must be a list of non-empty strings"]
@@ -169,6 +279,12 @@ def validate_admissibility_against_profile(
             f"destination mismatch: record {record_destination!r}, profile {profile_destination!r}"
         )
 
+    if profile.get("runtime_identity") != record.get("runtime_identity"):
+        errors.append(
+            "runtime identity mismatch: "
+            f"record {record.get('runtime_identity')!r}, profile {profile.get('runtime_identity')!r}"
+        )
+
     profile_available = profile.get("available_capabilities")
     record_available = record.get("available_capabilities")
     if isinstance(profile_available, list) and isinstance(record_available, list):
@@ -195,6 +311,13 @@ def validate_assignment_execution_contract(
     if record.get("status") != "ADMISSIBLE":
         errors.append("executable assignment cites a non-ADMISSIBLE record")
 
+    draft_id = record.get("assignment_draft_id")
+    draft_ref = contract.get("assignment_draft_ref")
+    if not isinstance(draft_ref, str) or not draft_ref.strip():
+        errors.append("assignment execution contract requires a non-empty assignment_draft_ref")
+    elif draft_ref != draft_id:
+        errors.append(f"assignment_draft_ref mismatch: assignment {draft_ref!r}, proof {draft_id!r}")
+
     record_id = record.get("artifact_id")
     if contract.get("admissibility_ref") != record_id:
         errors.append(
@@ -212,6 +335,13 @@ def validate_assignment_execution_contract(
     if contract.get("destination_id") != destination:
         errors.append(
             f"assignment destination mismatch: assignment {contract.get('destination_id')!r}, proof {destination!r}"
+        )
+
+    runtime_identity = record.get("runtime_identity")
+    if contract.get("runtime_identity") != runtime_identity:
+        errors.append(
+            "assignment runtime_identity mismatch: "
+            f"assignment {contract.get('runtime_identity')!r}, proof {runtime_identity!r}"
         )
 
     if contract.get("proof_status") != "PROVEN":


### PR DESCRIPTION
## Objective

Repair the independently verified fail-open defects in PR #33 executability proof-chain validation without redesigning unrelated architecture.

## Exact chain

- Base: `47281c39f1a33dcee8f061d3018c0387775d1889`
- Current HEAD: `fac954042fcd516a974df03f3e98f1d123952aa2`
- Target branch: `repair/executability-contract-01` (PR #33)

## Repair coverage

- bind executable ASSIGNMENT to the exact admitted draft via `assignment_draft_ref`;
- bind CAPABILITY_PROFILE → ASSIGNMENT_ADMISSIBILITY → ASSIGNMENT to the exact `runtime_identity`;
- require structured freshness boundaries and resolvable `CAPABILITY_EVIDENCE` artifacts;
- reject stale/expired/unresolved/runtime-mismatched evidence;
- validate the complete schema-required ASSIGNMENT surface in the advertised complete-chain validator/CLI;
- require evidence validity to cover the whole profile freshness interval;
- reject future-dated capability observations;
- reject schema-unique capability-list duplicates instead of silently normalizing them;
- validate all embedded evidence artifacts, including unreferenced structurally invalid artifacts;
- add direct function and CLI regressions for the complete chain and adversarial cases.

## Current validation evidence

The follow-up repair at `fac954042fcd516a974df03f3e98f1d123952aa2` was exercised in an isolated local reconstruction of the two modified Python files:

- `python -m py_compile tools/executability.py` — PASS;
- `python -m unittest -v tests.test_executability` — 19 tests, 19 PASS;
- additional adversarial checks for missing nullable-required schema keys, freshness-boundary extra fields, and non-RFC3339 timestamps — REJECTED as required;
- no trailing whitespace in either modified file.

The current environment still cannot clone GitHub (`Could not resolve host: github.com`), so a full repository-local suite is **not independently claimed at the current HEAD**. Earlier execution against the predecessor repair reproduced only the known inherited Research structural failure from the PR #33/base line; this PR does not modify Research policy surfaces.

## Scope

Changed by this follow-up repair only:

- `tools/executability.py`
- `tests/test_executability.py`

No Research lint repair, Canon change, Router redesign, external service, network dependency, new branch, or merge is included.

## Promotion

This PR is the bounded repair layer for PR #33. It should be merged into the PR #33 branch only after review of exact HEAD `fac954042fcd516a974df03f3e98f1d123952aa2`. Final PR #33 promotion to `main` remains a separate combined-state verification step.