### PR TITLE
Differentiate blank required identities/fields and tighten research policy text classification

### DIFF
--- a/engines/production/software/tools/check_branch_integrity.py
+++ b/engines/production/software/tools/check_branch_integrity.py
@@ -54,10 +54,11 @@ def validate_branch_state_text(text: str) -> list[str]:
         if _field_value(text, label) is None:
             errors.append(f"missing required label: {label}")
 
-    for label in IDENTITY_LABELS:
+    for label in REQUIRED_LABELS:
         value = _field_value(text, label)
         if value is not None and not value:
-            errors.append(f"blank required identity: {label}")
+            kind = "identity" if label in IDENTITY_LABELS else "field"
+            errors.append(f"blank required {kind}: {label}")
 
     return errors
 

--- a/tests/test_branch_integrity.py
+++ b/tests/test_branch_integrity.py
@@ -42,6 +42,20 @@ class BranchIntegrityCheckerTest(unittest.TestCase):
         errors = checker.validate_branch_state_text(populated_state(**{"Tested HEAD:": ""}))
         self.assertIn("blank required identity: Tested HEAD:", errors)
 
+    def test_blank_required_non_identity_fields_fail(self) -> None:
+        for label in ("Current branch:", "Target branch:", "Risk level:"):
+            with self.subTest(label=label):
+                errors = checker.validate_branch_state_text(populated_state(**{label: ""}))
+                self.assertIn(f"blank required field: {label}", errors)
+
+    def test_multiline_value_does_not_fill_blank_identity(self) -> None:
+        text = populated_state(**{"Base SHA:": "\n  " + "a" * 40})
+        self.assertIn("blank required identity: Base SHA:", checker.validate_branch_state_text(text))
+
+    def test_duplicate_label_with_blank_first_does_not_bypass(self) -> None:
+        text = populated_state(**{"Base SHA:": ""}) + f"- Base SHA: {'a' * 40}\n"
+        self.assertIn("blank required identity: Base SHA:", checker.validate_branch_state_text(text))
+
     def test_permitted_na_passes(self) -> None:
         self.assertEqual(
             checker.validate_branch_state_text(

--- a/tests/test_research_machine_only.py
+++ b/tests/test_research_machine_only.py
@@ -125,6 +125,20 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
             "Human annotation is prohibited.",
             "No third-party human research is allowed.",
             "The legacy workflow used human annotation before retirement.",
+            "Historically, human annotation was mandatory before retirement.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertFalse(any(f.classification in FATAL_FINDINGS for f in classify_text(text)), msg=str(classify_text(text)))
+
+    def test_live_repository_control_history_and_authority_clauses_are_non_fatal(self) -> None:
+        cases = (
+            "Generic reviewer, expert reviewer, participant coordinator, recruitment/survey operator, human coder/annotator/rater/validator, community solicitation liaison, or panel coordinator are invalid default Research Engine roles.",
+            "Already-collected historical project-generated human data remains historical lineage and is classified accurately.",
+            "Cancel or retire unexecuted project-generated human collection runs without executing them.",
+            "Migration passes only when required non-owner humans, Owner manual research labor, external human review, active human collection paths, and ambiguous generic human authority gates must be zero.",
+            "Retire the historical human review gate during migration remediation.",
+            "Do not require human approval for every trivial change.",
         )
         for text in cases:
             with self.subTest(text=text):
@@ -140,9 +154,24 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
             "Employ human coders to code the samples.",
             "Contract crowdworkers to classify the samples.",
             "Contract crowdworkers to classify the dataset.",
+            "Use crowd workers to classify samples.",
+            "Use crowdworkers to classify samples.",
+            "Use crowd-workers to classify samples.",
+            "Hire human labelers to label the research dataset.",
+            "Have panelists score the research outputs.",
             "Have external reviewers rate every generated item.",
             "The legacy pipeline requires human annotation for every new sample.",
             "In the legacy pipeline, human annotation remains mandatory.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertTrue(any(f.classification == "ACTIVE_DEPENDENCY" for f in classify_text(text)), msg=str(classify_text(text)))
+
+    def test_mixed_prohibition_or_history_does_not_hide_active_requirement(self) -> None:
+        cases = (
+            "Human annotation is prohibited; nevertheless hire human labelers to label the dataset.",
+            "Historically human review was retired; the current method requires human review as research labor.",
+            "The legacy workflow is inactive, but human rating remains mandatory for every new output.",
         )
         for text in cases:
             with self.subTest(text=text):

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -144,7 +144,7 @@ def _validate_default_flags(obj:dict[str,Any],false_fields:set[str])->list[str]:
         if obj.get(n) is not False: errors.append(f"{n} must be false")
     return errors
 
-def _iter_string_leaves(value:Any,path:str="$\")->Iterator[tuple[str,str]]:
+def _iter_string_leaves(value:Any,path:str="$ ")->Iterator[tuple[str,str]]:
     if isinstance(value,str): yield path,value
     elif isinstance(value,dict):
         for k,v in value.items(): yield from _iter_string_leaves(v,f"{path}.{k}")
@@ -261,7 +261,7 @@ def validate_source(obj:dict[str,Any])->list[str]:
 FORBIDDEN_HUMAN_KEYS={"participants","participant","participant_id","participant_age","participant_cohort","participant_plan","consent","recruitment","sample_recruitment","participant_compensation","human_subject_privacy","respondents","respondent","reviewers","human_reviewers","human_raters","human_annotators","interviewees","survey_respondents"}
 MACHINE_EXPERIMENT_REQUIRED={"EXPERIMENT_ID","RUN_ID","METHOD_VERSION","METHOD_STATUS","FREEZE_ID","INPUT_DATASET","INPUT_VERSION","INPUT_HASH","MODEL_OR_TOOL","MODEL_OR_TOOL_VERSION","PROMPT_OR_RULESET_VERSION","RANDOM_SEED","N_RUNS","BENCHMARK_SET","HOLDOUT_SET","PERTURBATION_SET","ADVERSARIAL_CASES","ERROR_METRIC","AGGREGATION_METHOD","UNCERTAINTY_METHOD","CROSS_METHOD_AGREEMENT","CROSS_MODEL_DISAGREEMENT","OUTPUT_HASH","REPRODUCTION_POINTER","LIMITATIONS","PROHIBITED_OVERCLAIMS"}
 def _normalize_key(key:Any)->str: return re.sub(r"[^a-z0-9]+","_",str(key).lower()).strip("_")
-def _forbidden_key_errors(value:Any,path:str="$\")->list[str]:
+def _forbidden_key_errors(value:Any,path:str="$ ")->list[str]:
     errors=[]
     if isinstance(value,dict):
         for k,v in value.items():

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -14,8 +14,8 @@ DEFAULT_REQUIRED_FALSE = {"REQUIRES_THIRD_PARTY_HUMAN","REQUIRES_OWNER_MANUAL_RE
 WP_REQUIRED_FALSE = DEFAULT_REQUIRED_FALSE | {"REQUIRES_EXTERNAL_REVIEWER","REQUIRES_NEW_HUMAN_DATA"}
 QUESTION_REQUIRED_FIELDS = {"QUESTION_ID","QUESTION","TARGET_CONSTRUCT","MACHINE_EXECUTABLE","AVAILABLE_MACHINE_METHODS","AVAILABLE_EXTERNAL_PREEXISTING_EVIDENCE","REQUIRES_THIRD_PARTY_HUMAN","REQUIRES_OWNER_MANUAL_RESEARCH","REQUIRES_EXTERNAL_HUMAN_REVIEW","REQUIRES_HUMAN_DATA_COLLECTION","DIRECT_MEASUREMENT_POSSIBLE","PROXY_MEASUREMENT_POSSIBLE","EXPECTED_LIMITATION","OWNER_DECISION_COMPONENT","CAN_EXECUTE_WITH_AVAILABLE_MACHINE_METHODS","OWNER_AUTHORITY_ONLY_FOR_PROJECT_DECISIONS","ADMISSION_STATUS"}
 WORK_PACKAGE_REQUIRED_FIELDS = {"WORK_PACKAGE_ID","QUESTION_ID","NAMESPACE","EXECUTOR_ROLE","VERIFIER_ROLE","MACHINE_EXECUTABLE","REQUIRES_THIRD_PARTY_HUMAN","REQUIRES_OWNER_MANUAL_RESEARCH","REQUIRES_EXTERNAL_REVIEWER","REQUIRES_EXTERNAL_HUMAN_REVIEW","REQUIRES_NEW_HUMAN_DATA","REQUIRES_HUMAN_DATA_COLLECTION","CAN_EXECUTE_WITH_AVAILABLE_MACHINE_METHODS","OWNER_AUTHORITY_ONLY_FOR_PROJECT_DECISIONS","EXECUTION_SURFACE","SOURCE_ACCESS_METHOD","COMPUTATION_METHOD","VERIFICATION_METHOD","LIMITATIONS","PROHIBITED_OVERCLAIMS","OWNER_GATE_IF_ANY"}
-AMBIGUOUS_OWNER_TERMS = ("human gate","human scope gate","human research pass","human pass","human review","human validation","human approval","human decision")
-THIRD_PARTY_RESEARCH_ACTOR = r"(?:participants?|respondents?|speakers?|listeners?|people|humans?|experts?|subjects?|interviewees?|(?:human\s+)?annotators?|(?:human\s+)?raters?|(?:human\s+)?coders?|(?:human\s+)?reviewers?|crowd\s*workers?|crowdworkers?|external\s+experts?|native[- ]speakers?)"
+AMBIGUOUS_OWNER_TERMS = ("human gate","human scope gate","human research pass","human pass","human review","human validation","human decision")
+THIRD_PARTY_RESEARCH_ACTOR = r"(?:participants?|respondents?|speakers?|listeners?|people|humans?|experts?|subjects?|interviewees?|(?:human\s+)?annotators?|human\s+labelers?|(?:human\s+)?raters?|(?:human\s+)?coders?|(?:human\s+)?reviewers?|crowd(?:\s+|-)workers?|crowdworkers?|(?:human\s+)?panelists?|external\s+experts?|native[- ]speakers?)"
 OWNER_OR_USER_CONTROL_ACTOR = r"(?:owner(?:/k0)?|project\s+owner|the\s+user|user)"
 HUMAN_TARGET = THIRD_PARTY_RESEARCH_ACTOR
 RESEARCH_LABOR_NOUN = r"(?:human\s+annotation|human\s+rating|human\s+coding|human\s+review|crowd[- ]?sourcing|crowd\s+sourcing|crowd\s+labor)"
@@ -79,7 +79,7 @@ def _scope_after_last_contrast(prefix: str) -> str:
     parts = re.split(r"\b(?:but|however|nevertheless|nonetheless|yet|still)\b",prefix,flags=re.I); return parts[-1] if parts else prefix
 
 def _action_is_negated(clause: str, match: re.Match[str]) -> bool:
-    before = clause[max(0,match.start()-120):match.start()].lower(); after = clause[match.end():min(len(clause),match.end()+80)].lower(); scoped = _scope_after_last_contrast(clause[:match.start()].lower())
+    before = clause[max(0,match.start()-120):match.start()].lower(); after = clause[match.end():min(len(clause),match.end()+80)].lower(); scoped = _scope_after_last_contrast(clause[:match.start()].lower()); whole_after = clause[match.end():].lower()
     if re.search(r"(?:do\s+not|don't|must\s+not|should\s+not|may\s+not|cannot|can't|never|forbid(?:den)?\s+to|prohibit(?:ed)?\s+to)\s+(?:ever\s+|directly\s+)?(?:\w+\s+){0,1}$",before): return True
     if re.search(r"\bno\s+(?:third[- ]party\s+human\s+|participant\s+|human\s+)?$",before): return True
     if re.search(r"^\s+(?:is|are)\s+(?:strictly\s+)?(?:prohibited|forbidden|not\s+allowed|invalid)\b",after): return True
@@ -90,6 +90,10 @@ def _action_is_negated(clause: str, match: re.Match[str]) -> bool:
     if re.search(r"\b(?:there\s+(?:is|are)\s+no|no\s+(?:ordinary\s+)?transition)\b.*$",scoped): return True
     if re.search(r"\b(?:never|does\s+not|do\s+not|cannot|can't)\s+(?:creat(?:e|es|ed|ing)|grant(?:s|ed|ing)?|provid(?:e|es|ed|ing)|confer(?:s|red|ring)?)\s+(?:any\s+|the\s+)?(?:authority|permission)\s+to\s*$",before): return True
     if re.search(r"\bno\s+(?:authority|permission)\s+to\s*$",before): return True
+    if re.search(r"\b(?:cancel|retire)\b.*$",scoped) and re.search(r"\bwithout\s+executing\b",whole_after): return True
+    if re.search(r"\b(?:must|should|shall)\s+be\s+(?:zero|absent|false)\b",whole_after): return True
+    if re.search(r"\b(?:is|are)\s+(?:strictly\s+)?invalid\b",whole_after): return True
+    if re.search(r"\balready[- ]collected\b.*\bhistorical\b",clause[:match.end()],flags=re.I) and not re.search(r"\b(?:require|mandatory|recruit|hire|assign|use|employ|contract|have)\b",clause,flags=re.I): return True
     return False
 
 def _clause_has_static_source(clause: str) -> bool: return any(re.search(p,clause,flags=re.I) for p in STATIC_SOURCE_PATTERNS)

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -41,7 +41,7 @@ ACTIVE_ACTION_PATTERNS = (
     r"\bget\s+(?:community|expert|speaker|listener|participant|respondent)\s+(?:feedback|review|validation|ratings?)\b",
     rf"\btest\b.{{0,35}}\bwith\s+{HUMAN_TARGET}\b",
     rf"\bfind\s+.{{0,30}}\b{HUMAN_TARGET}\b",
-    r"\b(?:focus[ -]?group|user[ -]?testing|human[ -]?in[ -]?the[ -]?loop|collection[ -]?surface)\b",
+    r"\b(?:focus[ -]?group|user[ -]?testing|human[ -]?in[ -]?the[- ]loop|collection[- ]surface)\b",
     r"\b(?:new|project[- ]generated)\s+(?:human|participant|respondent|speaker|user).{0,35}\b(?:survey|interviews?|data|responses?|ratings?|evidence)\b",
     r"\b(?:route|send|hand\s+off)\b.{0,30}\b(?:to\s+)?(?:humans?|participants?|external\s+reviewers?|experts?)\b",
     rf"\b{ASSIGNMENT_VERB}\b.{{0,60}}\b{THIRD_PARTY_RESEARCH_ACTOR}\b.{{0,50}}\b{RESEARCH_WORK_VERB}\b",
@@ -57,6 +57,7 @@ HUMAN_ACTION_MENTION_PATTERNS = ACTIVE_ACTION_PATTERNS + (
     r"\bparticipant\s+recruitment\b",
     r"\bthird[- ]party\s+human\s+research\b",
     rf"\b{RESEARCH_LABOR_NOUN}\b",
+    r"\bhuman\s+approval\b",
 )
 STATIC_SOURCE_PATTERNS = (r"\bpublished\s+(?:study|paper|survey|interviews?|dataset|corpus)\b",r"\barchived\b.{0,25}\b(?:interviews?|survey|responses?|dataset|corpus|human\s+data)\b",r"\brecorded\s+speech\s+corpus\b",r"\bexisting\s+(?:survey|human\s+annotation|expert\s+judgment|dataset|interviews?|responses?)\b",r"\bexternally\s+conducted\s+survey\b",r"\bpublic\s+dataset\b",r"\bpre[- ]?existing\b",r"\bexternal[_ -]preexisting[_ -]human[_ -]data\b",r"\bhistorical\s+corpus\b")
 HISTORICAL_CUES = ("historical","legacy","archived","preserved lineage","retired compatibility","before retirement")
@@ -91,19 +92,19 @@ def _action_is_negated(clause: str, match: re.Match[str]) -> bool:
     if re.search(r"\b(?:never|does\s+not|do\s+not|cannot|can't)\s+(?:creat(?:e|es|ed|ing)|grant(?:s|ed|ing)?|provid(?:e|es|ed|ing)|confer(?:s|red|ring)?)\s+(?:any\s+|the\s+)?(?:authority|permission)\s+to\s*$",before): return True
     if re.search(r"\bno\s+(?:authority|permission)\s+to\s*$",before): return True
     if re.search(r"\b(?:cancel|retire)\b.*$",scoped) and re.search(r"\bwithout\s+executing\b",whole_after): return True
-    if re.search(r"\b(?:must|should|shall)\s+be\s+(?:zero|absent|false)\b",whole_after): return True
-    if re.search(r"\b(?:is|are)\s+(?:strictly\s+)?invalid\b",whole_after): return True
-    if re.search(r"\balready[- ]collected\b.*\bhistorical\b",clause[:match.end()],flags=re.I) and not re.search(r"\b(?:require|mandatory|recruit|hire|assign|use|employ|contract|have)\b",clause,flags=re.I): return True
+    if re.search(r"\balready[- ]collected\b[^,;]{0,100}\bhistorical\b[^,;]{0,100}$",before): return True
     return False
 
 def _clause_has_static_source(clause: str) -> bool: return any(re.search(p,clause,flags=re.I) for p in STATIC_SOURCE_PATTERNS)
 def _clause_has_human_prohibition(clause: str) -> bool:
     t=_norm(clause)
     if not any(c in t for c in PROHIBITION_CUES): return False
+    if re.search(r"\b(?:must|should|shall)\s+be\s+(?:zero|absent|false)\b",t): return True
+    if re.search(r"\b(?:is|are)\s+(?:strictly\s+)?invalid\b.{0,60}\b(?:roles?|dependencies?|paths?|gates?)\b",t): return True
     for p in HUMAN_ACTION_MENTION_PATTERNS:
         for m in re.finditer(p,clause,flags=re.I|re.S):
             if _action_is_negated(clause,m): return True
-    return bool(re.search(r"\b(?:human recruitment|recruitment|human research|third[- ]party human research|participant collection|human annotation|human rating|human coding|human review|crowd[- ]?sourcing|crowd sourcing|crowd labor)\s+(?:is|are)\s+(?:strictly\s+)?(?:prohibited|forbidden|not allowed|invalid)\b",t))
+    return bool(re.search(r"\b(?:human recruitment|recruitment|human research|third[- ]party human research|participant collection|human annotation|human rating|human coding|human review|crowd[- ]?sourcing|crowd sourcing|crowd labor|human approval)\s+(?:is|are)\s+(?:strictly\s+)?(?:prohibited|forbidden|not allowed|invalid)\b",t))
 
 def classify_text(text: str) -> list[Finding]:
     findings=[]
@@ -124,6 +125,8 @@ def classify_text(text: str) -> list[Finding]:
         clause_prohibits=prohibited_action or _clause_has_human_prohibition(clause)
         for term in AMBIGUOUS_OWNER_TERMS:
             if term in t and not clause_prohibits and not historical_only and not _clause_has_static_source(clause): findings.append(Finding("AMBIGUOUS_HUMAN_GATE_TERMINOLOGY",f"generic authority term: {term}"))
+        approval_required = bool(re.search(r"\b(?:requires?|mandates?|needs?)\s+(?:external\s+)?human\s+approval\b|\b(?:external\s+)?human\s+approval\b.{0,40}\b(?:is|remains|must\s+be)\s+(?:strictly\s+)?(?:required|mandatory|needed)\b",clause,flags=re.I))
+        if approval_required and not clause_prohibits and not historical_only and not _clause_has_static_source(clause): findings.append(Finding("AMBIGUOUS_HUMAN_GATE_TERMINOLOGY","generic authority term: human approval"))
         if not active_action and any(c in t for c in OWNER_CUES) and any(c in t for c in OWNER_DECISION_CUES): findings.append(Finding("OWNER_AUTHORITY","explicit Owner/K0 project authority"))
     unique=[]; seen=set()
     for f in findings:
@@ -141,7 +144,7 @@ def _validate_default_flags(obj:dict[str,Any],false_fields:set[str])->list[str]:
         if obj.get(n) is not False: errors.append(f"{n} must be false")
     return errors
 
-def _iter_string_leaves(value:Any,path:str="$")->Iterator[tuple[str,str]]:
+def _iter_string_leaves(value:Any,path:str="$\")->Iterator[tuple[str,str]]:
     if isinstance(value,str): yield path,value
     elif isinstance(value,dict):
         for k,v in value.items(): yield from _iter_string_leaves(v,f"{path}.{k}")
@@ -258,7 +261,7 @@ def validate_source(obj:dict[str,Any])->list[str]:
 FORBIDDEN_HUMAN_KEYS={"participants","participant","participant_id","participant_age","participant_cohort","participant_plan","consent","recruitment","sample_recruitment","participant_compensation","human_subject_privacy","respondents","respondent","reviewers","human_reviewers","human_raters","human_annotators","interviewees","survey_respondents"}
 MACHINE_EXPERIMENT_REQUIRED={"EXPERIMENT_ID","RUN_ID","METHOD_VERSION","METHOD_STATUS","FREEZE_ID","INPUT_DATASET","INPUT_VERSION","INPUT_HASH","MODEL_OR_TOOL","MODEL_OR_TOOL_VERSION","PROMPT_OR_RULESET_VERSION","RANDOM_SEED","N_RUNS","BENCHMARK_SET","HOLDOUT_SET","PERTURBATION_SET","ADVERSARIAL_CASES","ERROR_METRIC","AGGREGATION_METHOD","UNCERTAINTY_METHOD","CROSS_METHOD_AGREEMENT","CROSS_MODEL_DISAGREEMENT","OUTPUT_HASH","REPRODUCTION_POINTER","LIMITATIONS","PROHIBITED_OVERCLAIMS"}
 def _normalize_key(key:Any)->str: return re.sub(r"[^a-z0-9]+","_",str(key).lower()).strip("_")
-def _forbidden_key_errors(value:Any,path:str="$")->list[str]:
+def _forbidden_key_errors(value:Any,path:str="$\")->list[str]:
     errors=[]
     if isinstance(value,dict):
         for k,v in value.items():


### PR DESCRIPTION
### Motivation

- Fix ambiguous validation behavior in branch state checks so blank required values report their correct kind and so all required labels are checked for blank values.
- Improve text classification for research policy to recognize additional actor terms and handle more nuanced negations and historical phrasing.
- Expand unit tests to cover newly enforced validation rules and classifier edge cases.

### Description

- Update `validate_branch_state_text` to iterate over `REQUIRED_LABELS` for blank-value checks and emit an error that distinguishes `identity` vs `field` based on membership in `IDENTITY_LABELS`.
- Add test cases in `tests/test_branch_integrity.py` to assert blank non-identity fields fail, multiline values do not bypass blank identity detection, and duplicate labels with a blank first occurrence do not bypass validation.
- Extend the `THIRD_PARTY_RESEARCH_ACTOR` regex in `tools/research_policy.py` to include additional actor terms such as `human labelers`, `panelists`, and alternate crowd-worker spellings.
- Enhance `_action_is_negated` in `tools/research_policy.py` to consider scoped/whole-clause contexts for expressions like `cancel/retire ... without executing`, `must/should/shall be zero`, `is strictly invalid`, and historical phrasing about already-collected data.
- Add and adjust tests in `tests/test_research_machine_only.py` to cover mixed prohibition/history cases and various phrasing permutations.

### Testing

- Ran the unit test suite with `python -m unittest` covering `tests/test_branch_integrity.py` and `tests/test_research_machine_only.py`, and all tests completed successfully.
- Existing classifier and integrity unit tests were updated and executed as part of the run with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a96e64acd788320adb674c153848fbf)