### PR TITLE
Replace research negation heuristics with scoped action grammar

### DIFF
--- a/tests/test_research_machine_only.py
+++ b/tests/test_research_machine_only.py
@@ -10,8 +10,6 @@ sys.path.insert(0, str(ROOT))
 
 from tools.research_policy import (
     FATAL_FINDINGS,
-    _action_is_negated,
-    _iter_action_matches,
     classify_text,
     machine_only_regression_results,
     validate_experiment,
@@ -230,17 +228,90 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                 self.assertIn("EXPLICIT_PROHIBITION", classes, classify_text(text))
                 self.assertIn("ACTIVE_DEPENDENCY", classes, classify_text(text))
 
-    def test_action_negation_is_match_local_within_one_clause(self) -> None:
-        clause = "There is no ordinary transition to participant recruitment, but recruit human participants under the alternate path."
-        decisions = []
-        spans = set()
-        for action_span, match in _iter_action_matches(clause):
-            key = (action_span, match.start(), match.end())
-            if key not in spans:
-                spans.add(key)
-                decisions.append((match.group(0), _action_is_negated(action_span, match)))
-        self.assertTrue(any(negated for _, negated in decisions), decisions)
-        self.assertTrue(any(not negated for _, negated in decisions), decisions)
+    def test_direct_shared_governor_cases(self) -> None:
+        cases = (
+            "There is no ordinary transition to recruit human participants and survey respondents.",
+            "There is no ordinary transition to recruit human participants or survey respondents.",
+            "Prohibited: recruit human participants and survey respondents.",
+            "Forbidden: recruit human participants and survey respondents.",
+            "Default-deny controls: recruit human participants and survey respondents.",
+            "Never recruit human participants and survey respondents.",
+            "Do not recruit human participants and survey respondents.",
+            "Must not recruit human participants and survey respondents.",
+            "Should not recruit human participants and survey respondents.",
+            "Cannot recruit human participants and survey respondents.",
+            "No authority to recruit human participants and survey respondents.",
+            "Prohibited: recruit human participants, survey respondents, and interview speakers.",
+            "Never recruit human participants, survey respondents, and interview speakers.",
+            "There is no ordinary transition to recruit human participants, survey respondents, or interview speakers.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                classes = {f.classification for f in classify_text(text)}
+                self.assertIn("EXPLICIT_PROHIBITION", classes)
+                self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+
+    def test_generated_shared_governor_action_coordination_matrix(self) -> None:
+        governors = ("Never ", "Do not ", "Must not ", "Should not ", "Cannot ", "Prohibited: ", "Forbidden: ", "Default-deny controls: ", "There is no ordinary transition to ", "There is no authority to ")
+        actions = ("recruit human participants", "survey respondents", "interview speakers", "hire human annotators", "use human raters to score outputs", "contact external experts")
+        coordinators = (" and ", " or ", ", ", ", and ", ", or ")
+        for governor in governors:
+            for index, action in enumerate(actions):
+                other = actions[(index + 1) % len(actions)]
+                for coordinator in coordinators:
+                    text = governor + action + coordinator + other + "."
+                    with self.subTest(text=text):
+                        classes = {f.classification for f in classify_text(text)}
+                        self.assertIn("EXPLICIT_PROHIBITION", classes)
+                        self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+
+    def test_generated_bidirectional_contrast_matrix(self) -> None:
+        markers = ("but", "however", "yet", "nevertheless", "nonetheless")
+        pairs = (("recruit human participants", "survey respondents"), ("hire human annotators", "contact external experts"), ("interview speakers", "use human raters to score outputs"))
+        for marker in markers:
+            for first, second in pairs:
+                for text in (f"Prohibited: {first}, {marker} {second}.", f"{first}, {marker} never {second}."):
+                    with self.subTest(text=text):
+                        self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text(text)})
+
+    def test_direct_active_and_mixed_cases(self) -> None:
+        cases = (
+            "There is no ordinary transition to participant recruitment, but recruit human participants under the alternate path.",
+            "Prohibited: recruit human participants, but recruit respondents under the exception path.",
+            "Never recruit human participants by default, but recruit 20 participants under the alternate path.",
+            "Human annotation is forbidden; however hire human labelers for the new dataset.",
+            "There is no ordinary transition to human review, yet human reviewers score every new output on the alternate path.",
+            "Already-collected historical project-generated human data remains historical lineage and human reviewers score every new output.",
+            "Already-collected historical human data remains preserved, and human reviewers score every new output.",
+            "Retire the old participant collection without executing it and recruit 20 new participants.",
+            "Recruit 20 participants and never recruit human participants in the fallback path.",
+            "Use a published survey and recruit 20 new respondents.",
+            "Analyze archived interviews and interview five new speakers.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text(text)})
+        for text in cases[:5]:
+            with self.subTest(coexisting=text):
+                self.assertIn("EXPLICIT_PROHIBITION", {f.classification for f in classify_text(text)})
+
+    def test_metamorphic_scope_invariants(self) -> None:
+        actions = ("recruit human participants", "survey respondents", "interview speakers")
+        for joiner in (" and ", " or ", ", ", ", and ", ", or "):
+            governed = "Prohibited: " + joiner.join(actions) + "."
+            self.assertNotIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text(governed)})  # M1
+            self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text(joiner.join(actions) + ".")})  # M2/M6
+        self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text("Prohibited: recruit human participants, but survey respondents.")})  # M3
+        self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text("Published survey evidence is historical, and recruit human participants.")})  # M4
+        self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text("Recruit human participants, but never survey respondents.")})  # M5
+
+    def test_markdown_governed_list_scope(self) -> None:
+        governed = "Prohibited:\n\n- recruit human participants\n- survey respondents\n- interview speakers"
+        classes = {f.classification for f in classify_text(governed)}
+        self.assertIn("EXPLICIT_PROHIBITION", classes)
+        self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+        mixed = "Prohibited:\n\n- recruit human participants\n- survey respondents\n\nHowever, recruit external experts under the exception path."
+        self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text(mixed)})
 
     def test_pure_and_genuinely_list_wide_prohibitions_remain_non_active(self) -> None:
         cases = (

--- a/tests/test_research_machine_only.py
+++ b/tests/test_research_machine_only.py
@@ -292,8 +292,46 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                         units = _policy_units(wrapped)
                         propositions = [part for unit in units for part in _propositions(unit)]
                         decisions = [decision for number, proposition in enumerate(propositions) for decision in _action_dispositions(proposition, number)]
-                        self.assertGreaterEqual(len({decision.action.lower() for decision in decisions}), 2, decisions)
+                        self.assertEqual({decision.source_item_index for decision in decisions}, {0, 1}, decisions)
+                        for source_item_index in (0, 1):
+                            item_decisions = [decision for decision in decisions if decision.source_item_index == source_item_index]
+                            self.assertTrue(item_decisions, decisions)
+                            self.assertEqual(len({decision.source_item_text for decision in item_decisions}), 1, item_decisions)
+                            self.assertTrue(all(decision.disposition == "NON_ACTIVE" for decision in item_decisions), item_decisions)
                         self.assertTrue(all(decision.disposition == "NON_ACTIVE" for decision in decisions), decisions)
+
+    def test_source_action_identity_for_governed_ungoverned_and_wrapped_pairs(self) -> None:
+        cases = (
+            ("Prohibited: recruit human participants and survey respondents.", "NON_ACTIVE"),
+            ("recruit human participants and survey respondents.", "ACTIVE"),
+            ("Prohibited: recruit human participants\nand survey respondents.", "NON_ACTIVE"),
+            ("Prohibited: use human raters to score outputs\nand contact external experts.", "NON_ACTIVE"),
+        )
+        for text, disposition in cases:
+            units = _policy_units(text)
+            propositions = [part for unit in units for part in _propositions(unit)]
+            decisions = [decision for number, proposition in enumerate(propositions) for decision in _action_dispositions(proposition, number)]
+            with self.subTest(text=text):
+                self.assertEqual({decision.source_item_index for decision in decisions}, {0, 1}, decisions)
+                for source_item_index in (0, 1):
+                    item_decisions = [decision for decision in decisions if decision.source_item_index == source_item_index]
+                    self.assertTrue(item_decisions, decisions)
+                    self.assertEqual({decision.disposition for decision in item_decisions}, {disposition})
+                    self.assertEqual(len({decision.source_item_text for decision in item_decisions}), 1)
+
+    def test_overlapping_matches_preserve_source_action_identity(self) -> None:
+        text = "Prohibited: use human raters to score outputs and contact external experts."
+        proposition = _propositions(_policy_units(text)[0])[0]
+        decisions = _action_dispositions(proposition, 0)
+        first = [decision for decision in decisions if decision.source_item_index == 0]
+        second = [decision for decision in decisions if decision.source_item_index == 1]
+        self.assertGreater(len(first), 1, decisions)
+        self.assertTrue(second, decisions)
+        self.assertEqual({decision.source_item_index for decision in first}, {0})
+        self.assertEqual({decision.source_item_text for decision in first}, {"use human raters to score outputs"})
+        self.assertEqual({decision.source_item_index for decision in second}, {1})
+        self.assertEqual({decision.source_item_text for decision in second}, {"contact external experts."})
+        self.assertTrue(all(decision.disposition == "NON_ACTIVE" for decision in decisions))
 
     def test_generated_bidirectional_contrast_matrix(self) -> None:
         markers = ("but", "however", "yet", "nevertheless", "nonetheless")
@@ -400,6 +438,35 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
         self.assertIn("ACTIVE_DEPENDENCY", self.classification_classes("- recruit human participants\n  and survey respondents"))
         stopped = "Prohibited:\n\n- recruit human participants\n- survey respondents\n\nRecruit external experts under the exception path."
         self.assertIn("ACTIVE_DEPENDENCY", self.classification_classes(stopped))
+
+    def test_atx_headings_are_structural_policy_boundaries(self) -> None:
+        safe = (
+            "# Research transition policy\nThere is no ordinary transition to recruit human participants\nand survey respondents.",
+            "### Policy\nThere is no ordinary transition to\nrecruit human participants\nand survey respondents.",
+            "###### Policy\nProhibited: recruit human participants\nand survey respondents.",
+            "# Research policy\nProhibited:\n\n- recruit human participants\n- survey respondents",
+            "   ## Research policy\nProhibited:\n\n- recruit human participants\n- survey respondents",
+        )
+        for text in safe:
+            with self.subTest(safe=text):
+                classes = self.classification_classes(text)
+                self.assertIn("EXPLICIT_PROHIBITION", classes)
+                self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+        active = "## Policy\nRecruit human participants\nand survey respondents."
+        self.assertIn("ACTIVE_DEPENDENCY", self.classification_classes(active))
+        terminated = "There is no ordinary transition to recruit human participants.\n## Alternate method\nRecruit external experts for the new study."
+        classes = self.classification_classes(terminated)
+        self.assertIn("EXPLICIT_PROHIBITION", classes)
+        self.assertIn("ACTIVE_DEPENDENCY", classes)
+        self.assertEqual(_policy_units("# Heading with recruit participants\nMachine-only prose."), ["Machine-only prose."])
+
+    def test_atx_heading_grammar_is_bounded(self) -> None:
+        self.assertEqual(_policy_units("# Heading\ntext"), ["text"])
+        self.assertEqual(_policy_units("   ###### Heading\ntext"), ["text"])
+        self.assertEqual(_policy_units("#not-a-heading\ntext"), ["#not-a-heading text"])
+        self.assertEqual(_policy_units("foo # bar\ntext"), ["foo # bar text"])
+        self.assertEqual(_policy_units("    # four-leading-spaces-is-not-an-ATX-heading\ntext"), ["# four-leading-spaces-is-not-an-ATX-heading text"])
+        self.assertEqual(_policy_units("####### not-a-heading\ntext"), ["####### not-a-heading text"])
 
     def test_metamorphic_scope_invariants(self) -> None:
         actions = ("recruit human participants", "survey respondents", "interview speakers")

--- a/tests/test_research_machine_only.py
+++ b/tests/test_research_machine_only.py
@@ -10,6 +10,9 @@ sys.path.insert(0, str(ROOT))
 
 from tools.research_policy import (
     FATAL_FINDINGS,
+    _action_dispositions,
+    _policy_units,
+    _propositions,
     classify_text,
     machine_only_regression_results,
     validate_experiment,
@@ -102,6 +105,10 @@ def base_freeze() -> dict:
 
 
 class ResearchMachineOnlyPolicyTest(unittest.TestCase):
+    @staticmethod
+    def classification_classes(text: str) -> set[str]:
+        return {finding.classification for finding in classify_text(text)}
+
     def test_T01_T42_bounded_regression_matrix(self) -> None:
         results = machine_only_regression_results()
         self.assertEqual(set(results), {f"T{i:02d}" for i in range(1,43)})
@@ -265,6 +272,29 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                         self.assertIn("EXPLICIT_PROHIBITION", classes)
                         self.assertNotIn("ACTIVE_DEPENDENCY", classes)
 
+    def test_generated_soft_wrap_matrix_and_action_observability(self) -> None:
+        governors = ("Never ", "Do not ", "Must not ", "Should not ", "Cannot ", "Prohibited: ", "Forbidden: ", "Default-deny controls: ", "There is no ordinary transition to ", "There is no authority to ")
+        actions = ("recruit human participants", "survey respondents", "interview speakers", "hire human annotators", "use human raters to score outputs", "contact external experts")
+        coordinators = ((" and ", "\nand "), (" or ", "\nor "), (", ", ",\n"), (", and ", ",\nand "), (", or ", ",\nor "))
+        for action in actions:
+            with self.subTest(standalone=action):
+                self.assertIn("ACTIVE_DEPENDENCY", self.classification_classes(action + "."))
+        for governor in governors:
+            for index, action in enumerate(actions):
+                other = actions[(index + 1) % len(actions)]
+                for single_joiner, wrapped_joiner in coordinators:
+                    single = governor + action + single_joiner + other + "."
+                    wrapped = governor + action + wrapped_joiner + other + "."
+                    with self.subTest(wrapped=wrapped):
+                        self.assertEqual(self.classification_classes(single), self.classification_classes(wrapped))
+                        self.assertIn("EXPLICIT_PROHIBITION", self.classification_classes(wrapped))
+                        self.assertNotIn("ACTIVE_DEPENDENCY", self.classification_classes(wrapped))
+                        units = _policy_units(wrapped)
+                        propositions = [part for unit in units for part in _propositions(unit)]
+                        decisions = [decision for number, proposition in enumerate(propositions) for decision in _action_dispositions(proposition, number)]
+                        self.assertGreaterEqual(len({decision.action.lower() for decision in decisions}), 2, decisions)
+                        self.assertTrue(all(decision.disposition == "NON_ACTIVE" for decision in decisions), decisions)
+
     def test_generated_bidirectional_contrast_matrix(self) -> None:
         markers = ("but", "however", "yet", "nevertheless", "nonetheless")
         pairs = (("recruit human participants", "survey respondents"), ("hire human annotators", "contact external experts"), ("interview speakers", "use human raters to score outputs"))
@@ -273,6 +303,20 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                 for text in (f"Prohibited: {first}, {marker} {second}.", f"{first}, {marker} never {second}."):
                     with self.subTest(text=text):
                         self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text(text)})
+
+    def test_generated_contrast_wrap_matrix(self) -> None:
+        markers = ("but", "however", "yet", "nevertheless", "nonetheless")
+        pairs = (("recruit human participants", "survey respondents"), ("hire human annotators", "contact external experts"), ("interview speakers", "use human raters to score outputs"))
+        for marker in markers:
+            for first, second in pairs:
+                layouts = (
+                    (f"Prohibited: {first}, {marker} {second}.", f"Prohibited: {first},\n{marker} {second}."),
+                    (f"{first}, {marker} never {second}.", f"{first},\n{marker} never {second}."),
+                )
+                for single, wrapped in layouts:
+                    with self.subTest(wrapped=wrapped):
+                        self.assertEqual(self.classification_classes(single), self.classification_classes(wrapped))
+                        self.assertIn("ACTIVE_DEPENDENCY", self.classification_classes(wrapped))
 
     def test_direct_active_and_mixed_cases(self) -> None:
         cases = (
@@ -295,6 +339,68 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
             with self.subTest(coexisting=text):
                 self.assertIn("EXPLICIT_PROHIBITION", {f.classification for f in classify_text(text)})
 
+    def test_direct_multiline_safe_and_active_layout_invariance(self) -> None:
+        safe = (
+            "There is no ordinary transition to recruit human participants\nand survey respondents.",
+            "There is no ordinary transition to\nrecruit human participants and survey respondents.",
+            "There is no ordinary transition to recruit\nhuman participants and survey respondents.",
+            "There is no ordinary transition to recruit human participants\nor survey respondents.",
+            "Prohibited: recruit human participants\nand survey respondents.",
+            "Forbidden: recruit human participants\nand survey respondents.",
+            "Default-deny controls: recruit human participants\nand survey respondents.",
+            "Never recruit human participants\nand survey respondents.",
+            "Do not recruit human participants\nand survey respondents.",
+            "Must not recruit human participants\nand survey respondents.",
+            "Cannot recruit human participants\nand survey respondents.",
+            "There is no authority to recruit human participants\nand survey respondents.",
+            "Prohibited: recruit human participants,\nsurvey respondents,\nand interview speakers.",
+            "There is no ordinary transition to recruit human participants,\nsurvey respondents,\nor interview speakers.",
+        )
+        active = (
+            "There is no ordinary transition to participant recruitment,\nbut recruit human participants under the alternate path.",
+            "Prohibited: recruit human participants,\nbut recruit respondents under the exception path.",
+            "Never recruit human participants by default,\nbut recruit 20 participants under the alternate path.",
+            "Already-collected historical project-generated human data\nremains historical lineage and human reviewers score every new output.",
+            "Already-collected historical human data remains preserved,\nand human reviewers score every new output.",
+            "Retire the old participant collection without executing it\nand recruit 20 new participants.",
+            "Recruit 20 participants\nand never recruit human participants in the fallback path.",
+            "Use a published survey\nand recruit 20 new respondents.",
+            "Analyze archived interviews\nand interview five new speakers.",
+        )
+        for text in safe:
+            with self.subTest(safe=text):
+                classes = self.classification_classes(text)
+                self.assertIn("EXPLICIT_PROHIBITION", classes)
+                self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+                self.assertEqual(classes, self.classification_classes(text.replace("\n", " ")))
+        for text in active:
+            with self.subTest(active=text):
+                classes = self.classification_classes(text)
+                self.assertIn("ACTIVE_DEPENDENCY", classes)
+                self.assertEqual(classes, self.classification_classes(text.replace("\n", " ")))
+
+    def test_paragraph_and_markdown_structural_boundaries(self) -> None:
+        paragraphs = (
+            "Prohibited: recruit human participants.\n\nRecruit external experts under the alternate method.",
+            "There is no ordinary transition to recruit human participants\nand survey respondents.\n\nRecruit external experts under the alternate method.",
+            "Never recruit human participants.\n\nSurvey respondents for the new study.",
+        )
+        for text in paragraphs:
+            with self.subTest(paragraph=text):
+                classes = self.classification_classes(text)
+                self.assertIn("EXPLICIT_PROHIBITION", classes)
+                self.assertIn("ACTIVE_DEPENDENCY", classes)
+        governed = "Prohibited:\n\n- recruit human participants\n  and survey respondents\n- interview speakers"
+        governed_action = "Prohibited:\n\n- use human raters\n  to score outputs\n- contact external experts"
+        for text in (governed, governed_action):
+            with self.subTest(governed=text):
+                classes = self.classification_classes(text)
+                self.assertIn("EXPLICIT_PROHIBITION", classes)
+                self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+        self.assertIn("ACTIVE_DEPENDENCY", self.classification_classes("- recruit human participants\n  and survey respondents"))
+        stopped = "Prohibited:\n\n- recruit human participants\n- survey respondents\n\nRecruit external experts under the exception path."
+        self.assertIn("ACTIVE_DEPENDENCY", self.classification_classes(stopped))
+
     def test_metamorphic_scope_invariants(self) -> None:
         actions = ("recruit human participants", "survey respondents", "interview speakers")
         for joiner in (" and ", " or ", ", ", ", and ", ", or "):
@@ -304,6 +410,15 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
         self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text("Prohibited: recruit human participants, but survey respondents.")})  # M3
         self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text("Published survey evidence is historical, and recruit human participants.")})  # M4
         self.assertIn("ACTIVE_DEPENDENCY", {f.classification for f in classify_text("Recruit human participants, but never survey respondents.")})  # M5
+        layouts = (
+            ("Prohibited: recruit human participants and survey respondents.", "Prohibited: recruit human participants\nand survey respondents."),
+            ("Recruit human participants and survey respondents.", "Recruit human participants\nand survey respondents."),
+            ("Prohibited: recruit human participants, but survey respondents.", "Prohibited: recruit human participants,\nbut survey respondents."),
+            ("Historical human data is preserved, and recruit human participants.", "Historical human data is preserved,\nand recruit human participants."),
+            ("Use a published survey and recruit human participants.", "Use a published survey\nand recruit human participants."),
+        )
+        for single, wrapped in layouts:
+            self.assertEqual(self.classification_classes(single), self.classification_classes(wrapped))  # M7
 
     def test_markdown_governed_list_scope(self) -> None:
         governed = "Prohibited:\n\n- recruit human participants\n- survey respondents\n- interview speakers"

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -77,11 +77,14 @@ def _norm(text: str) -> str: return re.sub(r"\s+"," ",text.lower()).strip()
 POLICY_HEADING = re.compile(r"^\s*(?:[-*]\s+)?(?:\*\*)?(?:prohibited|forbidden|default[- ]deny(?:\s+controls?)?)(?:\*\*)?\s*:\s*(.*)$", re.I)
 CONTRAST = re.compile(r"\s*(?:,\s*|\b)(?:but|however|yet|nevertheless|nonetheless)\b[,\s]*", re.I)
 BULLET = re.compile(r"^\s*[-*]\s+(\S.*)$")
+ATX_HEADING = re.compile(r"^ {0,3}#{1,6}(?=\s|$)")
 
 @dataclass(frozen=True)
 class ActionDisposition:
     action: str
     proposition_id: int
+    source_item_index: int
+    source_item_text: str
     governor: str | None
     disposition: str
     reason: str
@@ -111,6 +114,10 @@ def _policy_units(text: str) -> list[str]:
     i = 0
     while i < len(lines):
         if not lines[i].strip():
+            flush_prose()
+            i += 1
+            continue
+        if ATX_HEADING.match(lines[i]):
             flush_prose()
             i += 1
             continue
@@ -157,7 +164,21 @@ def _shared_governor(proposition: str) -> str | None:
     if re.fullmatch(r"migration passes only when .+\b(?:dependencies|paths|gates) must be zero\.?", t): return "terminal zero predicate"
     return None
 
-def _action_matches(proposition: str) -> Iterator[tuple[str, re.Match[str]]]:
+def _source_item_text(item: str, source_item_index: int, governor: str | None) -> str:
+    if source_item_index != 0 or governor is None:
+        return item.strip()
+    heading = POLICY_HEADING.match(item)
+    if heading:
+        return heading.group(1).strip()
+    governed_prefix = re.compile(
+        r"^\s*(?:(?:never|do\s+not|does\s+not|must\s+not|should\s+not|may\s+not|cannot|can't)\b|"
+        r"(?:there\s+(?:is\s+no\s+ordinary\s+transition|are\s+no\s+ordinary\s+transitions|is\s+no\s+authority|is\s+no\s+permission)\s+to|"
+        r"no\s+(?:ordinary\s+transition|authority|permission)\s+to)\b)\s*",
+        re.I,
+    )
+    return governed_prefix.sub("", item, count=1).strip()
+
+def _action_matches(proposition: str) -> Iterator[tuple[int, str, re.Match[str]]]:
     """Decompose action items only after proposition scope is resolved.
 
     Coordination is a lexical item delimiter here, never evidence for or against
@@ -165,14 +186,16 @@ def _action_matches(proposition: str) -> Iterator[tuple[str, re.Match[str]]]:
     recognizers from consuming a separately disposable neighboring action.
     """
     items = re.split(r"\s*,\s*|\s+\b(?:and|or)\b\s+", proposition, flags=re.I)
-    for item in items:
+    governor = _shared_governor(proposition)
+    for source_item_index, item in enumerate(items):
+        source_item_text = _source_item_text(item, source_item_index, governor)
         seen: set[tuple[int, int]] = set()
         for pattern in ACTIVE_ACTION_PATTERNS:
-            for match in re.finditer(pattern, item, flags=re.I | re.S):
+            for match in re.finditer(pattern, source_item_text, flags=re.I | re.S):
                 key = (match.start(), match.end())
                 if key not in seen:
                     seen.add(key)
-                    yield item, match
+                    yield source_item_index, source_item_text, match
 
 def _local_non_active(proposition: str, match: re.Match[str]) -> str | None:
     before = proposition[:match.start()].lower()[-100:]
@@ -188,10 +211,10 @@ def _local_non_active(proposition: str, match: re.Match[str]) -> str | None:
 def _action_dispositions(proposition: str, proposition_id: int) -> list[ActionDisposition]:
     governor = _shared_governor(proposition)
     decisions = []
-    for item, match in _action_matches(proposition):
-        local = _local_non_active(item, match)
+    for source_item_index, source_item_text, match in _action_matches(proposition):
+        local = _local_non_active(source_item_text, match)
         reason = governor or local
-        decisions.append(ActionDisposition(match.group(0), proposition_id, governor, "NON_ACTIVE" if reason else "ACTIVE", reason or "no supported non-active scope"))
+        decisions.append(ActionDisposition(match.group(0), proposition_id, source_item_index, source_item_text, governor, "NON_ACTIVE" if reason else "ACTIVE", reason or "no supported non-active scope"))
     return decisions
 
 def _clause_has_static_source(clause: str) -> bool: return any(re.search(p,clause,flags=re.I) for p in STATIC_SOURCE_PATTERNS)

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -76,6 +76,7 @@ class Finding:
 def _norm(text: str) -> str: return re.sub(r"\s+"," ",text.lower()).strip()
 POLICY_HEADING = re.compile(r"^\s*(?:[-*]\s+)?(?:\*\*)?(?:prohibited|forbidden|default[- ]deny(?:\s+controls?)?)(?:\*\*)?\s*:\s*(.*)$", re.I)
 CONTRAST = re.compile(r"\s*(?:,\s*|\b)(?:but|however|yet|nevertheless|nonetheless)\b[,\s]*", re.I)
+BULLET = re.compile(r"^\s*[-*]\s+(\S.*)$")
 
 @dataclass(frozen=True)
 class ActionDisposition:
@@ -86,25 +87,57 @@ class ActionDisposition:
     reason: str
 
 def _policy_units(text: str) -> list[str]:
-    """Preserve only recognized headings and their immediately attached bullets."""
+    """Assemble bounded Markdown structures without treating soft wraps as scope."""
     lines = str(text).replace("\r\n", "\n").replace("\r", "\n").split("\n")
     units: list[str] = []
+    prose: list[str] = []
+
+    def flush_prose() -> None:
+        if prose:
+            units.append(" ".join(part.strip() for part in prose))
+            prose.clear()
+
+    def bullet_item(start: int) -> tuple[str, int]:
+        match = BULLET.match(lines[start])
+        parts = [match.group(1)] if match else []
+        cursor = start + 1
+        while cursor < len(lines) and lines[cursor].strip() and not BULLET.match(lines[cursor]):
+            if not lines[cursor][:1].isspace():
+                break
+            parts.append(lines[cursor].strip())
+            cursor += 1
+        return " ".join(parts), cursor
+
     i = 0
     while i < len(lines):
+        if not lines[i].strip():
+            flush_prose()
+            i += 1
+            continue
         heading = POLICY_HEADING.match(lines[i])
         if heading and not heading.group(1).strip():
-            bullets: list[str] = []
+            flush_prose()
+            items: list[str] = []
             j = i + 1
             while j < len(lines) and not lines[j].strip(): j += 1
-            while j < len(lines) and re.match(r"^\s*[-*]\s+\S", lines[j]):
-                bullets.append(re.sub(r"^\s*[-*]\s+", "", lines[j]).strip())
-                j += 1
-            if bullets:
-                units.append(f"{lines[i].strip()} " + ", ".join(bullets))
+            while j < len(lines) and BULLET.match(lines[j]):
+                item, j = bullet_item(j)
+                items.append(item)
+            if items:
+                units.append(f"{lines[i].strip()} " + ", ".join(items))
                 i = j
                 continue
-        if lines[i].strip(): units.append(lines[i].strip())
+            units.append(lines[i].strip())
+            i += 1
+            continue
+        if BULLET.match(lines[i]):
+            flush_prose()
+            item, i = bullet_item(i)
+            units.append(f"- {item}")
+            continue
+        prose.append(lines[i])
         i += 1
+    flush_prose()
     return units
 
 def _propositions(unit: str) -> list[str]:

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -74,106 +74,92 @@ class Finding:
     message: str
 
 def _norm(text: str) -> str: return re.sub(r"\s+"," ",text.lower()).strip()
-def _split_clauses(text: str) -> list[str]:
-    normalized = str(text).replace("\r\n","\n").replace("\r","\n")
-    return [p.strip() for p in re.split(r"(?:\n+|(?<=[.!?])\s+|\s*;\s*)",normalized) if p.strip()]
-def _local_action_span(clause: str, match: re.Match[str]) -> tuple[str, str]:
-    """Return text locally governing an action, never an unrelated conjunct.
+POLICY_HEADING = re.compile(r"^\s*(?:[-*]\s+)?(?:\*\*)?(?:prohibited|forbidden|default[- ]deny(?:\s+controls?)?)(?:\*\*)?\s*:\s*(.*)$", re.I)
+CONTRAST = re.compile(r"\s*(?:,\s*|\b)(?:but|however|yet|nevertheless|nonetheless)\b[,\s]*", re.I)
 
-    Commas and coordinating/contrast conjunctions are semantic span boundaries for
-    policy negation.  This deliberately makes a later active action win over a
-    historical/prohibited action earlier in the same grammatical sentence.
+@dataclass(frozen=True)
+class ActionDisposition:
+    action: str
+    proposition_id: int
+    governor: str | None
+    disposition: str
+    reason: str
+
+def _policy_units(text: str) -> list[str]:
+    """Preserve only recognized headings and their immediately attached bullets."""
+    lines = str(text).replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    units: list[str] = []
+    i = 0
+    while i < len(lines):
+        heading = POLICY_HEADING.match(lines[i])
+        if heading and not heading.group(1).strip():
+            bullets: list[str] = []
+            j = i + 1
+            while j < len(lines) and not lines[j].strip(): j += 1
+            while j < len(lines) and re.match(r"^\s*[-*]\s+\S", lines[j]):
+                bullets.append(re.sub(r"^\s*[-*]\s+", "", lines[j]).strip())
+                j += 1
+            if bullets:
+                units.append(f"{lines[i].strip()} " + ", ".join(bullets))
+                i = j
+                continue
+        if lines[i].strip(): units.append(lines[i].strip())
+        i += 1
+    return units
+
+def _propositions(unit: str) -> list[str]:
+    return [p.strip() for p in re.split(r"(?<=[.!?])\s+|\s*;\s*", unit) if p.strip() for p in CONTRAST.split(p) if p.strip()]
+
+def _shared_governor(proposition: str) -> str | None:
+    t = _norm(proposition)
+    leading = re.match(r"^(?:[-*]\s*)?(never|do not|does not|must not|should not|may not|cannot|can't)\b", t)
+    if leading: return leading.group(1)
+    heading = POLICY_HEADING.match(proposition)
+    if heading: return _norm(proposition[:heading.end() - len(heading.group(1))])
+    denial = re.match(r"^(?:there (?:is no ordinary transition|are no ordinary transitions|is no authority|is no permission) to|no (?:ordinary transition|authority|permission) to)\b", t)
+    if denial: return denial.group(0)
+    authority_denial = re.search(r"\b(?:never|does not|do not|cannot|can't)\s+(?:create|creates|grant|grants|provide|provides|confer|confers)\s+(?:any\s+|the\s+)?(?:authority|permission)\s+to\b", t)
+    if authority_denial: return authority_denial.group(0)
+    if re.fullmatch(r"(?:no default role may be instantiated as an arbitrary external person\.\s*)?generic\s+`?reviewer`?,.*\bare invalid default research engine roles\.?", t): return "terminal invalid-role predicate"
+    if re.fullmatch(r"migration passes only when .+\b(?:dependencies|paths|gates) must be zero\.?", t): return "terminal zero predicate"
+    return None
+
+def _action_matches(proposition: str) -> Iterator[tuple[str, re.Match[str]]]:
+    """Decompose action items only after proposition scope is resolved.
+
+    Coordination is a lexical item delimiter here, never evidence for or against
+    shared scope.  Returning the item alongside its match keeps broad legacy
+    recognizers from consuming a separately disposable neighboring action.
     """
-    boundary = r"(?:[,;]|\b(?:and|but|however|nevertheless|nonetheless|yet)\b)"
-    left = list(re.finditer(boundary, clause[:match.start()], flags=re.I))
-    right = re.search(boundary, clause[match.end():], flags=re.I)
-    start = left[-1].end() if left else 0
-    end = match.end() + (right.start() if right else len(clause) - match.end())
-    return clause[start:match.start()].lower(), clause[match.end():end].lower()
-
-def _iter_action_matches(clause: str) -> Iterator[tuple[str, re.Match[str]]]:
-    """Yield action matches from independent coordination/contrast spans.
-
-    Bounded wildcard patterns therefore cannot merge an active action on one side
-    of a semantic boundary with a negated action on the other side.
-    """
-    hard_boundary = r"(?:[,;]|\b(?:but|however|nevertheless|nonetheless|yet)\b)"
-    hard_spans = (part.strip() for part in re.split(hard_boundary, clause, flags=re.I))
-    spans: list[str] = []
-    for hard_span in hard_spans:
-        coordinated = re.split(r"\band\b", hard_span, flags=re.I)
-        current = coordinated[0].strip() if coordinated else ""
-        for right in coordinated[1:]:
-            right = right.strip()
-            negation_governs_bare_coordination = bool(re.search(
-                r"\b(?:never|do\s+not|does\s+not|must\s+not|should\s+not|may\s+not|cannot|can't)\b",
-                current,
-                flags=re.I,
-            )) and bool(re.match(
-                r"(?:recruit|survey|interview|hire|assign|use|employ|contract|have|collect|gather|solicit|obtain|ask|contact|consult|review|rate|score|annotate|label|code|classify|assess|evaluate)\b",
-                right,
-                flags=re.I,
-            ))
-            if negation_governs_bare_coordination:
-                current = f"{current} and {right}"
-            else:
-                spans.append(current)
-                current = right
-        spans.append(current)
-    for span in spans:
-        span = span.strip()
-        if not span:
-            continue
+    items = re.split(r"\s*,\s*|\s+\b(?:and|or)\b\s+", proposition, flags=re.I)
+    for item in items:
+        seen: set[tuple[int, int]] = set()
         for pattern in ACTIVE_ACTION_PATTERNS:
-            for match in re.finditer(pattern, span, flags=re.I | re.S):
-                yield span, match
+            for match in re.finditer(pattern, item, flags=re.I | re.S):
+                key = (match.start(), match.end())
+                if key not in seen:
+                    seen.add(key)
+                    yield item, match
 
-def _action_is_negated(clause: str, match: re.Match[str]) -> bool:
-    local_before, local_after = _local_action_span(clause, match)
-    before = local_before[-120:]; after = local_after[:80]; scoped = local_before; whole_after = local_after
-    # Every decision below is anchored to this match's local span. Clause-wide
-    # grammatical predicates are classified separately and never leak through
-    # this action-local API.
+def _local_non_active(proposition: str, match: re.Match[str]) -> str | None:
+    before = proposition[:match.start()].lower()[-100:]
+    after = proposition[match.end():].lower()[:100]
     matched = match.group(0).lower()
-    if re.search(r"\b(?:must\s+not|should\s+not|may\s+not|do\s+not|does\s+not|never|cannot|can't)\b", matched): return True
-    if re.search(r"(?:do\s+not|don't|must\s+not|should\s+not|may\s+not|cannot|can't|never|forbid(?:den)?\s+to|prohibit(?:ed)?\s+to)\s+(?:ever\s+|directly\s+)?(?:\w+\s+){0,1}$",before): return True
-    if re.search(r"\bno\s+(?:third[- ]party\s+human\s+|participant\s+|human\s+)?$",before): return True
-    if re.search(r"^\s+(?:is|are)\s+(?:strictly\s+)?(?:prohibited|forbidden|not\s+allowed|invalid)\b",after): return True
-    if re.search(r"^\s+(?:must|should|may)\s+(?:be\s+)?(?:prohibited|forbidden|zero|absent|false)\b",after): return True
-    if re.match(r"^\s*(?:[-*]\s*)*(?:\*\*)?(?:prohibited|forbidden)(?:\*\*)?\s*:",scoped): return True
-    if re.match(r"^\s*(?:[-*]\s*)*(?:\*\*)?default[- ]deny(?:\s+controls?)?(?:\*\*)?\s*:",scoped): return True
-    if re.search(r"\b(?:must|should|may|can)\s+not\s+(?:be\s+)?(?:assigned|include|involve|require|create|enter|route|introduce|use|perform|conduct|authorize|permit)\b.*$",scoped): return True
-    if re.search(r"\b(?:there\s+(?:is|are)\s+no|no\s+(?:ordinary\s+)?transition)\b.*$",scoped): return True
-    if re.search(r"\b(?:never|does\s+not|do\s+not|cannot|can't)\s+(?:creat(?:e|es|ed|ing)|grant(?:s|ed|ing)?|provid(?:e|es|ed|ing)|confer(?:s|red|ring)?)\s+(?:any\s+|the\s+)?(?:authority|permission)\s+to\s*$",before): return True
-    if re.search(r"\bno\s+(?:authority|permission)\s+to\s*$",before): return True
-    if re.search(r"\b(?:cancel|retire)\b.*$",scoped) and re.search(r"\bwithout\s+executing\b",whole_after): return True
-    if re.search(r"\balready[- ]collected\b[^,;]{0,100}\bhistorical\b[^,;]{0,100}$",before): return True
-    return False
+    if re.search(r"\b(?:never|do\s+not|does\s+not|must\s+not|should\s+not|may\s+not|cannot|can't)\b", matched): return "local negation"
+    if re.search(r"\b(?:never|does\s+not|do\s+not|cannot|can't)\b[^,;]{0,70}$", before): return "local negation"
+    if re.search(r"\b(?:is|are)\s+(?:strictly\s+)?(?:prohibited|forbidden|not allowed|invalid)\b", after): return "local prohibition predicate"
+    if re.search(r"\b(?:cancel|retire)\b", before) and re.search(r"\bwithout\s+executing\b", after): return "retired without execution"
+    if re.search(r"\balready[- ]collected\b", before) and re.search(r"\bhistorical\b", before + matched + after): return "historical lineage"
+    return None
 
-def _clause_is_list_wide_prohibition(clause: str) -> bool:
-    """Recognize predicates that grammatically govern an entire completed list.
-
-    Both forms are anchored at the start and terminal predicate. Appending a
-    contrast/coordinated active action makes the full-clause form stop matching,
-    so this classification cannot paint an independent later action as negated.
-    """
-    normalized = _norm(clause)
-    invalid_roles = bool(re.fullmatch(
-        r"(?:no default role may be instantiated as an arbitrary external person\.\s*)?"
-        r"generic\s+`?reviewer`?,.*\bare invalid default research engine roles\.?",
-        normalized,
-    ))
-    migration_zero = bool(re.fullmatch(
-        r"migration passes only when .+\b(?:dependencies|paths|gates) must be zero\.?",
-        normalized,
-    ))
-    has_independent_boundary = bool(re.search(r"\b(?:and|but|however|nevertheless|nonetheless|yet)\b", normalized))
-    prohibited_heading = bool(re.match(
-        r"^(?:[-*]\s*)?(?:\*\*)?(?:prohibited|forbidden)(?:\*\*)?\s*:",
-        normalized,
-    )) and not has_independent_boundary
-    no_transition_list = normalized.startswith("there is no ordinary transition to ") and not has_independent_boundary
-    return invalid_roles or migration_zero or prohibited_heading or no_transition_list
+def _action_dispositions(proposition: str, proposition_id: int) -> list[ActionDisposition]:
+    governor = _shared_governor(proposition)
+    decisions = []
+    for item, match in _action_matches(proposition):
+        local = _local_non_active(item, match)
+        reason = governor or local
+        decisions.append(ActionDisposition(match.group(0), proposition_id, governor, "NON_ACTIVE" if reason else "ACTIVE", reason or "no supported non-active scope"))
+    return decisions
 
 def _clause_has_static_source(clause: str) -> bool: return any(re.search(p,clause,flags=re.I) for p in STATIC_SOURCE_PATTERNS)
 def _clause_has_human_prohibition(clause: str) -> bool:
@@ -182,28 +168,25 @@ def _clause_has_human_prohibition(clause: str) -> bool:
     if not any(c in t for c in PROHIBITION_CUES): return False
     if re.search(r"\b(?:must|should|shall)\s+be\s+(?:zero|absent|false)\b",t): return True
     if re.search(r"\b(?:is|are)\s+(?:strictly\s+)?invalid\b.{0,60}\b(?:roles?|dependencies?|paths?|gates?)\b",t): return True
-    for p in HUMAN_ACTION_MENTION_PATTERNS:
-        for m in re.finditer(p,clause,flags=re.I|re.S):
-            if _action_is_negated(clause,m): return True
     return bool(re.search(r"\b(?:human recruitment|recruitment|human research|third[- ]party human research|participant collection|human annotation|human rating|human coding|human review|crowd[- ]?sourcing|crowd sourcing|crowd labor|human approval)\s+(?:is|are)\s+(?:strictly\s+)?(?:prohibited|forbidden|not allowed|invalid)\b",t))
 
 def classify_text(text: str) -> list[Finding]:
     findings=[]
-    for clause in _split_clauses(text):
+    clauses = [p for unit in _policy_units(text) for p in _propositions(unit)]
+    for proposition_id, clause in enumerate(clauses):
         t=_norm(clause)
-        list_wide_prohibition = _clause_is_list_wide_prohibition(clause)
         for p in SIMULATED_HUMAN_OVERCLAIM:
             if re.search(p,clause,flags=re.I|re.S): findings.append(Finding("PROXY_OVERCLAIM","machine/simulated output is labeled as human responses"))
         if _clause_has_static_source(clause): findings.append(Finding("STATIC_EXTERNAL_SOURCE","pre-existing human-derived evidence"))
-        prohibited_action=False; active_action=False
-        for action_span, match in _iter_action_matches(clause):
-            if list_wide_prohibition or _action_is_negated(action_span,match): prohibited_action=True
-            else: active_action=True
+        dispositions = _action_dispositions(clause, proposition_id)
+        governed_mention = _shared_governor(clause) is not None and any(re.search(pattern, clause, flags=re.I | re.S) for pattern in HUMAN_ACTION_MENTION_PATTERNS)
+        prohibited_action=any(d.disposition == "NON_ACTIVE" for d in dispositions) or governed_mention
+        active_action=any(d.disposition == "ACTIVE" for d in dispositions)
         if prohibited_action or _clause_has_human_prohibition(clause): findings.append(Finding("EXPLICIT_PROHIBITION","human action is explicitly negated/prohibited"))
         if active_action: findings.append(Finding("ACTIVE_DEPENDENCY",f"active prohibited human research action: {clause[:180]}"))
         historical_only=any(c in t for c in HISTORICAL_CUES) and not active_action and not re.search(r"\b(?:run|execute|resume|deploy|start|recruit|collect|require|mandatory)\b",t)
         if historical_only and not _clause_has_static_source(clause): findings.append(Finding("HISTORICAL_REFERENCE","historical/legacy reference"))
-        clause_prohibits=prohibited_action or _clause_has_human_prohibition(clause)
+        clause_prohibits=prohibited_action or _clause_has_human_prohibition(clause) or _shared_governor(clause) is not None
         for term in AMBIGUOUS_OWNER_TERMS:
             if term in t and not clause_prohibits and not historical_only and not _clause_has_static_source(clause): findings.append(Finding("AMBIGUOUS_HUMAN_GATE_TERMINOLOGY",f"generic authority term: {term}"))
         approval_required = bool(re.search(r"\b(?:requires?|mandates?|needs?)\s+(?:external\s+)?human\s+approval\b|\b(?:external\s+)?human\s+approval\b.{0,40}\b(?:is|remains|must\s+be)\s+(?:strictly\s+)?(?:required|mandatory|needed)\b",clause,flags=re.I))


### PR DESCRIPTION
### Motivation

- Fix a post-merge R1 classifier defect where coordinated actions (e.g. "recruit human participants and survey respondents") could be split incorrectly so one action is negated while the other remains active.
- Replace the brittle coordination-as-boundary heuristic with a deterministic, per-action disposition model that preserves mixed findings and fails closed toward active dependencies when scope is ambiguous.

### Description

- Replace the old R3 helpers with a scoped pipeline that splits input into `POLICY_UNIT`s, then propositions (with explicit contrast resets), resolves a single `shared_governor`, decomposes coordinated action items, and assigns per-action `ActionDisposition` records (action, proposition id, governor, disposition, reason).
- Add `ActionDisposition` dataclass and new helpers (`_policy_units`, `_propositions`, `_shared_governor`, `_action_matches`, `_local_non_active`, `_action_dispositions`) while removing the prior `_local_action_span`, `_iter_action_matches`, `_action_is_negated`, and `_clause_is_list_wide_prohibition` heuristics.
- Preserve bounded Markdown governed lists (heading + immediate bullet list), treat contrast markers (`but`, `however`, `yet`, `nevertheless`, `nonetheless`) as hard scope resets, and ensure coordination tokens (`and`, `or`, comma) are only used for item decomposition, not as scope-deciding signals.
- Update and extend `tests/test_research_machine_only.py` with direct safe cases, generated shared-governor and contrast matrices, metamorphic invariants, mixed/active cases, and Markdown governed-list coverage to validate the new semantics.

### Testing

- Ran the unit regression suite with `python -m unittest -v tests.test_research_machine_only` and all tests passed (suite exercises direct, generated matrix, contrast, metamorphisms, and markdown cases). 
- Verified repository lint and policy checks with `python tools/research_policy.py --repo` which reported `Research machine-only policy: PASS`.
- Ran project structure validation with `python tools/validate_structure.py` and Python byte-compile with `python -m py_compile tools/research_policy.py`, both of which passed. 
- Executed the full test discovery with `python -m unittest discover -s tests -p 'test*.py'`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97224f05d48320b52c2bca1e51fe58)