### PR TITLE
Prevent trailing authority-denial from retroactively governing earlier actions

### DIFF
--- a/tests/test_research_machine_only.py
+++ b/tests/test_research_machine_only.py
@@ -272,6 +272,78 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                         self.assertIn("EXPLICIT_PROHIBITION", classes)
                         self.assertNotIn("ACTIVE_DEPENDENCY", classes)
 
+    def test_trailing_authority_denial_direct_mixed_cases(self) -> None:
+        cases = (
+            "Recruit human participants and this workflow never creates authority to recruit humans.",
+            "Survey respondents and this process does not grant permission to recruit human participants.",
+            "Interview speakers and the method cannot provide authority to recruit participants.",
+            "Hire human annotators and this workflow can't confer permission to recruit respondents.",
+            "Use human raters to score outputs and this workflow never creates authority to recruit humans.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                decisions = _action_dispositions(_propositions(_policy_units(text)[0])[0], 0)
+                classes = self.classification_classes(text)
+                self.assertIn("ACTIVE_DEPENDENCY", classes)
+                self.assertIn("EXPLICIT_PROHIBITION", classes)
+                self.assertEqual({d.disposition for d in decisions if d.source_item_index == 0}, {"ACTIVE"})
+                self.assertEqual({d.disposition for d in decisions if d.source_item_index == 1}, {"NON_ACTIVE"})
+
+    def test_subject_led_prefix_authority_denials_remain_safe(self) -> None:
+        cases = (
+            "This workflow never creates authority to recruit humans.",
+            "Unavailable direct measurement never creates authority to recruit humans.",
+            "This process does not grant permission to survey respondents.",
+            "The method cannot provide authority to interview speakers.",
+            "This workflow can't confer permission to contact external experts.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                classes = self.classification_classes(text)
+                self.assertIn("EXPLICIT_PROHIBITION", classes)
+                self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+
+    def test_generated_trailing_authority_denial_matrix(self) -> None:
+        actions = ("recruit human participants", "survey respondents", "interview speakers", "hire human annotators", "use human raters to score outputs", "contact external experts")
+        denials = (
+            "this workflow never creates authority to {}",
+            "this process does not grant permission to {}",
+            "the method cannot provide authority to {}",
+            "this workflow can't confer permission to {}",
+        )
+        layouts = (" and ", ", and ", "\nand ")
+        for index, action_a in enumerate(actions):
+            action_b = actions[(index + 1) % len(actions)]
+            for denial in denials:
+                for layout in layouts:
+                    text = action_a + layout + denial.format(action_b) + "."
+                    with self.subTest(text=text):
+                        proposition = _propositions(_policy_units(text)[0])[0]
+                        decisions = _action_dispositions(proposition, 0)
+                        classes = self.classification_classes(text)
+                        left = [d for d in decisions if d.source_item_index == 0]
+                        trailing = [d for d in decisions if d.source_item_index == 1]
+                        self.assertTrue(left, decisions)
+                        self.assertTrue(trailing, decisions)
+                        self.assertEqual({d.source_item_text for d in left}, {action_a})
+                        self.assertEqual({d.disposition for d in left}, {"ACTIVE"})
+                        self.assertEqual({d.disposition for d in trailing}, {"NON_ACTIVE"})
+                        self.assertIn("ACTIVE_DEPENDENCY", classes)
+                        self.assertIn("EXPLICIT_PROHIBITION", classes)
+
+    def test_trailing_denial_after_multiple_actions_and_prefix_control(self) -> None:
+        trailing = "Recruit human participants, survey respondents, and this workflow never creates authority to interview speakers."
+        decisions = _action_dispositions(_propositions(_policy_units(trailing)[0])[0], 0)
+        self.assertEqual({d.disposition for d in decisions if d.source_item_index in (0, 1)}, {"ACTIVE"})
+        self.assertEqual({d.disposition for d in decisions if d.source_item_index == 2}, {"NON_ACTIVE"})
+        self.assertTrue({"ACTIVE_DEPENDENCY", "EXPLICIT_PROHIBITION"}.issubset(self.classification_classes(trailing)))
+
+        prefix = "This workflow never creates authority to recruit human participants or survey respondents."
+        decisions = _action_dispositions(_propositions(_policy_units(prefix)[0])[0], 0)
+        self.assertEqual({d.source_item_index for d in decisions}, {0, 1})
+        self.assertEqual({d.disposition for d in decisions}, {"NON_ACTIVE"})
+        self.assertNotIn("ACTIVE_DEPENDENCY", self.classification_classes(prefix))
+
     def test_generated_soft_wrap_matrix_and_action_observability(self) -> None:
         governors = ("Never ", "Do not ", "Must not ", "Should not ", "Cannot ", "Prohibited: ", "Forbidden: ", "Default-deny controls: ", "There is no ordinary transition to ", "There is no authority to ")
         actions = ("recruit human participants", "survey respondents", "interview speakers", "hire human annotators", "use human raters to score outputs", "contact external experts")

--- a/tests/test_research_machine_only.py
+++ b/tests/test_research_machine_only.py
@@ -363,7 +363,7 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                 proposition = _propositions(_policy_units(text)[0])[0]
                 items, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
                 decisions = _action_dispositions(proposition, 0)
-                self.assertEqual(membership, expected_membership)
+                self.assertEqual(membership, {(index, 0): scope for index, scope in expected_membership.items()})
                 self.assertEqual({d.source_item_index for d in decisions if d.disposition == "ACTIVE"}, active_items)
                 for item in items:
                     self.assertEqual(proposition[item.source_item_start:item.source_item_end], item.source_item_text)
@@ -374,7 +374,7 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                     self.assertLessEqual(scope.governor_end, scope.governed_start)
                     self.assertLess(scope.governed_start, scope.governed_end)
                 for decision in decisions:
-                    self.assertEqual(decision.governor_scope_id, membership.get(decision.source_item_index))
+                    self.assertEqual(decision.governor_scope_id, membership.get((decision.source_item_index, decision.semantic_action_index)))
                     if decision.disposition == "NON_ACTIVE" and decision.governor is not None:
                         self.assertIsNotNone(decision.governor_scope_id)
 
@@ -382,7 +382,7 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
         no_reentry = "Never recruit human participants and under the alternate path survey respondents or interview speakers."
         proposition = _propositions(_policy_units(no_reentry)[0])[0]
         _, _, scopes, membership = _resolve_governor_scopes(proposition)
-        self.assertEqual(membership, {0: 0})
+        self.assertEqual(membership, {(0, 0): 0})
         self.assertEqual(len(scopes), 1)
         decisions = _action_dispositions(proposition, 0)
         self.assertEqual({d.source_item_index for d in decisions if d.disposition == "ACTIVE"}, {1, 2})
@@ -390,7 +390,7 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
         multiple = "Never recruit human participants and do not survey respondents or interview speakers."
         proposition = _propositions(_policy_units(multiple)[0])[0]
         _, _, scopes, membership = _resolve_governor_scopes(proposition)
-        self.assertEqual(membership, {0: 0, 1: 1, 2: 1})
+        self.assertEqual(membership, {(0, 0): 0, (1, 0): 1, (2, 0): 1})
         self.assertEqual(len(scopes), 2)
         self.assertLessEqual(scopes[0].governed_end, scopes[1].governor_start)
         self.assertNotIn("ACTIVE_DEPENDENCY", self.classification_classes(multiple))
@@ -402,8 +402,47 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                 proposition = _propositions(_policy_units(text)[0])[0]
                 _, _, _, membership = _resolve_governor_scopes(proposition)
                 decisions = _action_dispositions(proposition, 0)
-                self.assertEqual(membership, {0: 0})
+                self.assertEqual(membership, {(0, 0): 0})
                 self.assertEqual({d.disposition for d in decisions if d.source_item_index == 1}, {"ACTIVE"})
+                self.assertTrue({"ACTIVE_DEPENDENCY", "EXPLICIT_PROHIBITION"}.issubset(self.classification_classes(text)))
+
+    def test_same_item_distinct_occurrence_scope(self) -> None:
+        cases = (
+            ("Recruit human participants while this workflow never creates authority to recruit humans.", {0: None, 1: 0}),
+            ("This workflow never creates authority to recruit humans while recruit human participants.", {0: 0, 1: None}),
+        )
+        for text, expected_scope in cases:
+            with self.subTest(text=text):
+                proposition = _propositions(_policy_units(text)[0])[0]
+                items, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
+                decisions = _action_dispositions(proposition, 0)
+                self.assertEqual(len(items), 1)
+                self.assertGreaterEqual(len(occurrences), 2)
+                self.assertEqual({occurrence.semantic_action_index for occurrence in occurrences}, {0, 1})
+                self.assertEqual({occurrence.semantic_action_index: occurrence.governor_scope_id for occurrence in occurrences}, expected_scope)
+                self.assertEqual({occurrence.semantic_action_index: membership.get((0, occurrence.semantic_action_index)) for occurrence in occurrences}, expected_scope)
+                self.assertEqual({d.semantic_action_index: d.disposition for d in decisions}, {index: "NON_ACTIVE" if scope_id is not None else "ACTIVE" for index, scope_id in expected_scope.items()})
+                self.assertLess(occurrences[0].action_end, occurrences[1].action_start)
+                self.assertEqual(len(scopes), 1)
+                self.assertTrue({"ACTIVE_DEPENDENCY", "EXPLICIT_PROHIBITION"}.issubset(self.classification_classes(text)))
+
+    def test_non_action_gap_terminates_governor_scope(self) -> None:
+        cases = (
+            "Never recruit human participants and retain existing documentation or survey respondents.",
+            "There is no ordinary transition to recruit human participants and preserve the existing files or interview speakers.",
+            "Prohibited: recruit human participants and retain the existing dataset or survey respondents.",
+        )
+        for text in cases:
+            with self.subTest(text=text):
+                proposition = _propositions(_policy_units(text)[0])[0]
+                items, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
+                decisions = _action_dispositions(proposition, 0)
+                self.assertEqual(len(items), 3)
+                self.assertFalse([occurrence for occurrence in occurrences if occurrence.source_item_index == 1])
+                self.assertEqual(membership, {(0, 0): 0})
+                self.assertEqual({d.disposition for d in decisions if d.source_item_index == 0}, {"NON_ACTIVE"})
+                self.assertEqual({d.disposition for d in decisions if d.source_item_index == 2}, {"ACTIVE"})
+                self.assertEqual(len(scopes), 1)
                 self.assertTrue({"ACTIVE_DEPENDENCY", "EXPLICIT_PROHIBITION"}.issubset(self.classification_classes(text)))
 
     def test_governor_scope_soft_wrap_semantic_equivalence(self) -> None:
@@ -419,7 +458,7 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                     proposition = _propositions(_policy_units(text)[0])[0]
                     _, _, _, membership = _resolve_governor_scopes(proposition)
                     decisions = _action_dispositions(proposition, 0)
-                    return ([(d.source_item_index, membership.get(d.source_item_index)) for d in decisions], sorted(self.classification_classes(text)))
+                    return ([(d.source_item_index, membership.get((d.source_item_index, d.semantic_action_index))) for d in decisions], sorted(self.classification_classes(text)))
                 self.assertEqual(signature(single), signature(wrapped))
 
     def test_generated_bounded_governor_scope_matrix(self) -> None:
@@ -449,13 +488,14 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                             proposition = _propositions(_policy_units(text)[0])[0]
                             items, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
                             decisions = _action_dispositions(proposition, 0)
-                            self.assertEqual(membership, expected_membership)
+                            self.assertEqual(membership, {(index, 0): scope for index, scope in expected_membership.items()})
                             self.assertEqual({d.source_item_index for d in decisions if d.disposition == "ACTIVE"}, active_items)
                             self.assertEqual({d.source_item_index for d in decisions}, set(range(len(items))))
                             self.assertTrue(scopes)
-                            for index in membership:
-                                item_decisions = [d for d in decisions if d.source_item_index == index]
-                                self.assertEqual({d.governor_scope_id for d in item_decisions}, {membership[index]})
+                            for occurrence_key, scope_id in membership.items():
+                                item_index, semantic_action_index = occurrence_key
+                                item_decisions = [d for d in decisions if d.source_item_index == item_index and d.semantic_action_index == semantic_action_index]
+                                self.assertEqual({d.governor_scope_id for d in item_decisions}, {scope_id})
                             classes = self.classification_classes(text)
                             self.assertIn("EXPLICIT_PROHIBITION", classes)
                             if active_items:
@@ -521,6 +561,8 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
         self.assertEqual({decision.source_item_index for decision in first}, {0})
         self.assertEqual({decision.source_item_text for decision in first}, {"Prohibited: use human raters to score outputs"})
         self.assertEqual({(decision.source_item_start, decision.source_item_end) for decision in first}, {(0, len("Prohibited: use human raters to score outputs"))})
+        self.assertEqual({decision.semantic_action_index for decision in first}, {0})
+        self.assertEqual(len({(decision.semantic_action_start, decision.semantic_action_end) for decision in first}), 1)
         self.assertEqual({decision.governor_scope_id for decision in first}, {0})
         self.assertEqual({decision.source_item_index for decision in second}, {1})
         self.assertEqual({decision.source_item_text for decision in second}, {"contact external experts."})
@@ -535,6 +577,7 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
                 proposition = _propositions(_policy_units(text)[0])[0]
                 item_decisions = [d for d in _action_dispositions(proposition, 0) if d.source_item_index == item_index]
                 self.assertGreater(len(item_decisions), 1)
+                self.assertEqual(len({d.semantic_action_index for d in item_decisions}), 1)
                 self.assertEqual(len({(d.source_item_start, d.source_item_end) for d in item_decisions}), 1)
                 self.assertEqual({d.governor_scope_id for d in item_decisions}, {scope_id})
                 self.assertEqual({d.disposition for d in item_decisions}, {disposition})

--- a/tests/test_research_machine_only.py
+++ b/tests/test_research_machine_only.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(ROOT))
 from tools.research_policy import (
     FATAL_FINDINGS,
     _action_dispositions,
+    _resolve_governor_scopes,
     _policy_units,
     _propositions,
     classify_text,
@@ -344,6 +345,124 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
         self.assertEqual({d.disposition for d in decisions}, {"NON_ACTIVE"})
         self.assertNotIn("ACTIVE_DEPENDENCY", self.classification_classes(prefix))
 
+    def test_bounded_governor_scope_required_cases_and_provenance(self) -> None:
+        cases = (
+            ("Never recruit human participants or survey respondents.", {0: 0, 1: 0}, set()),
+            ("There is no ordinary transition to recruit human participants, survey respondents, or interview speakers.", {0: 0, 1: 0, 2: 0}, set()),
+            ("This workflow never creates authority to recruit human participants or survey respondents.", {0: 0, 1: 0}, set()),
+            ("Prohibited: recruit human participants and survey respondents.", {0: 0, 1: 0}, set()),
+            ("Recruit human participants and this workflow never creates authority to recruit humans.", {1: 0}, {0}),
+            ("This workflow never creates authority to recruit humans and under the alternate path recruit human participants.", {0: 0}, {1}),
+            ("Never recruit human participants and under the alternate path survey respondents.", {0: 0}, {1}),
+            ("There is no ordinary transition to recruit human participants and under the exception interview speakers.", {0: 0}, {1}),
+            ("Prohibited: recruit human participants and under the alternate method interview speakers.", {0: 0}, {1}),
+            ("Recruit human participants and this workflow never creates authority to survey respondents or interview speakers.", {1: 0, 2: 0}, {0}),
+        )
+        for text, expected_membership, active_items in cases:
+            with self.subTest(text=text):
+                proposition = _propositions(_policy_units(text)[0])[0]
+                items, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
+                decisions = _action_dispositions(proposition, 0)
+                self.assertEqual(membership, expected_membership)
+                self.assertEqual({d.source_item_index for d in decisions if d.disposition == "ACTIVE"}, active_items)
+                for item in items:
+                    self.assertEqual(proposition[item.source_item_start:item.source_item_end], item.source_item_text)
+                for occurrence in occurrences:
+                    self.assertEqual(proposition[occurrence.action_start:occurrence.action_end], occurrence.action)
+                for scope in scopes:
+                    self.assertEqual(proposition[scope.governor_start:scope.governor_end].strip(), scope.governor_text)
+                    self.assertLessEqual(scope.governor_end, scope.governed_start)
+                    self.assertLess(scope.governed_start, scope.governed_end)
+                for decision in decisions:
+                    self.assertEqual(decision.governor_scope_id, membership.get(decision.source_item_index))
+                    if decision.disposition == "NON_ACTIVE" and decision.governor is not None:
+                        self.assertIsNotNone(decision.governor_scope_id)
+
+    def test_scope_no_reentry_and_multiple_governor_non_overlap(self) -> None:
+        no_reentry = "Never recruit human participants and under the alternate path survey respondents or interview speakers."
+        proposition = _propositions(_policy_units(no_reentry)[0])[0]
+        _, _, scopes, membership = _resolve_governor_scopes(proposition)
+        self.assertEqual(membership, {0: 0})
+        self.assertEqual(len(scopes), 1)
+        decisions = _action_dispositions(proposition, 0)
+        self.assertEqual({d.source_item_index for d in decisions if d.disposition == "ACTIVE"}, {1, 2})
+
+        multiple = "Never recruit human participants and do not survey respondents or interview speakers."
+        proposition = _propositions(_policy_units(multiple)[0])[0]
+        _, _, scopes, membership = _resolve_governor_scopes(proposition)
+        self.assertEqual(membership, {0: 0, 1: 1, 2: 1})
+        self.assertEqual(len(scopes), 2)
+        self.assertLessEqual(scopes[0].governed_end, scopes[1].governor_start)
+        self.assertNotIn("ACTIVE_DEPENDENCY", self.classification_classes(multiple))
+
+    def test_unsupported_continuation_prefixes_fail_active(self) -> None:
+        for prefix, action in (("under the alternate path ", "recruit participants"), ("separately ", "survey respondents"), ("instead ", "interview speakers")):
+            text = f"Never recruit human participants and {prefix}{action}."
+            with self.subTest(text=text):
+                proposition = _propositions(_policy_units(text)[0])[0]
+                _, _, _, membership = _resolve_governor_scopes(proposition)
+                decisions = _action_dispositions(proposition, 0)
+                self.assertEqual(membership, {0: 0})
+                self.assertEqual({d.disposition for d in decisions if d.source_item_index == 1}, {"ACTIVE"})
+                self.assertTrue({"ACTIVE_DEPENDENCY", "EXPLICIT_PROHIBITION"}.issubset(self.classification_classes(text)))
+
+    def test_governor_scope_soft_wrap_semantic_equivalence(self) -> None:
+        pairs = (
+            ("Never recruit human participants or survey respondents.", "Never recruit human participants\nor survey respondents."),
+            ("This workflow never creates authority to recruit humans and under the alternate path recruit participants.", "This workflow never creates authority to recruit humans\nand under the alternate path recruit participants."),
+            ("Recruit participants and this workflow never creates authority to survey respondents or interview speakers.", "Recruit participants\nand this workflow never creates authority to survey respondents\nor interview speakers."),
+            ("Never recruit participants and do not survey respondents or interview speakers.", "Never recruit participants\nand do not survey respondents\nor interview speakers."),
+        )
+        for single, wrapped in pairs:
+            with self.subTest(wrapped=wrapped):
+                def signature(text: str) -> tuple[list[tuple[int, int | None]], list[str]]:
+                    proposition = _propositions(_policy_units(text)[0])[0]
+                    _, _, _, membership = _resolve_governor_scopes(proposition)
+                    decisions = _action_dispositions(proposition, 0)
+                    return ([(d.source_item_index, membership.get(d.source_item_index)) for d in decisions], sorted(self.classification_classes(text)))
+                self.assertEqual(signature(single), signature(wrapped))
+
+    def test_generated_bounded_governor_scope_matrix(self) -> None:
+        actions = ("recruit human participants", "survey respondents", "interview speakers", "hire human annotators", "use human raters to score outputs", "contact external experts")
+        governors = (
+            lambda action: f"Never {action}",
+            lambda action: f"There is no ordinary transition to {action}",
+            lambda action: f"This workflow never creates authority to {action}",
+            lambda action: f"Prohibited: {action}",
+        )
+        separators = ((" and ", "\nand "), (" or ", "\nor "), (", and ", ",\nand "))
+        for governor_index, governor in enumerate(governors):
+            for action_index, action_a in enumerate(actions):
+                action_b = actions[(action_index + 1) % len(actions)]
+                action_c = actions[(action_index + 2) % len(actions)]
+                separator_pair = separators[(governor_index + action_index) % len(separators)]
+                for wrapped, separator in enumerate(separator_pair):
+                    forward = "\nor " if wrapped else " or "
+                    shapes = (
+                        (governor(action_a) + separator + action_b + ".", {0: 0, 1: 0}, set()),
+                        (governor(action_a) + separator + "under an alternate path " + action_b + ".", {0: 0}, {1}),
+                        (action_a + separator + governor(action_b) + ".", {1: 0}, {0}),
+                        (action_a + separator + governor(action_b) + forward + action_c + ".", {1: 0, 2: 0}, {0}),
+                    )
+                    for text, expected_membership, active_items in shapes:
+                        with self.subTest(text=text):
+                            proposition = _propositions(_policy_units(text)[0])[0]
+                            items, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
+                            decisions = _action_dispositions(proposition, 0)
+                            self.assertEqual(membership, expected_membership)
+                            self.assertEqual({d.source_item_index for d in decisions if d.disposition == "ACTIVE"}, active_items)
+                            self.assertEqual({d.source_item_index for d in decisions}, set(range(len(items))))
+                            self.assertTrue(scopes)
+                            for index in membership:
+                                item_decisions = [d for d in decisions if d.source_item_index == index]
+                                self.assertEqual({d.governor_scope_id for d in item_decisions}, {membership[index]})
+                            classes = self.classification_classes(text)
+                            self.assertIn("EXPLICIT_PROHIBITION", classes)
+                            if active_items:
+                                self.assertIn("ACTIVE_DEPENDENCY", classes)
+                            else:
+                                self.assertNotIn("ACTIVE_DEPENDENCY", classes)
+
     def test_generated_soft_wrap_matrix_and_action_observability(self) -> None:
         governors = ("Never ", "Do not ", "Must not ", "Should not ", "Cannot ", "Prohibited: ", "Forbidden: ", "Default-deny controls: ", "There is no ordinary transition to ", "There is no authority to ")
         actions = ("recruit human participants", "survey respondents", "interview speakers", "hire human annotators", "use human raters to score outputs", "contact external experts")
@@ -400,10 +519,25 @@ class ResearchMachineOnlyPolicyTest(unittest.TestCase):
         self.assertGreater(len(first), 1, decisions)
         self.assertTrue(second, decisions)
         self.assertEqual({decision.source_item_index for decision in first}, {0})
-        self.assertEqual({decision.source_item_text for decision in first}, {"use human raters to score outputs"})
+        self.assertEqual({decision.source_item_text for decision in first}, {"Prohibited: use human raters to score outputs"})
+        self.assertEqual({(decision.source_item_start, decision.source_item_end) for decision in first}, {(0, len("Prohibited: use human raters to score outputs"))})
+        self.assertEqual({decision.governor_scope_id for decision in first}, {0})
         self.assertEqual({decision.source_item_index for decision in second}, {1})
         self.assertEqual({decision.source_item_text for decision in second}, {"contact external experts."})
         self.assertTrue(all(decision.disposition == "NON_ACTIVE" for decision in decisions))
+
+        cases = (
+            ("use human raters to score outputs and Never recruit participants.", 0, None, "ACTIVE"),
+            ("Never recruit participants or use human raters to score outputs.", 1, 0, "NON_ACTIVE"),
+        )
+        for text, item_index, scope_id, disposition in cases:
+            with self.subTest(text=text):
+                proposition = _propositions(_policy_units(text)[0])[0]
+                item_decisions = [d for d in _action_dispositions(proposition, 0) if d.source_item_index == item_index]
+                self.assertGreater(len(item_decisions), 1)
+                self.assertEqual(len({(d.source_item_start, d.source_item_end) for d in item_decisions}), 1)
+                self.assertEqual({d.governor_scope_id for d in item_decisions}, {scope_id})
+                self.assertEqual({d.disposition for d in item_decisions}, {disposition})
 
     def test_generated_bidirectional_contrast_matrix(self) -> None:
         markers = ("but", "however", "yet", "nevertheless", "nonetheless")

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -150,6 +150,18 @@ def _policy_units(text: str) -> list[str]:
 def _propositions(unit: str) -> list[str]:
     return [p.strip() for p in re.split(r"(?<=[.!?])\s+|\s*;\s*", unit) if p.strip() for p in CONTRAST.split(p) if p.strip()]
 
+AUTHORITY_DENIAL = re.compile(
+    r"\b(?:never|does not|do not|cannot|can't)\s+"
+    r"(?:create|creates|grant|grants|provide|provides|confer|confers)\s+"
+    r"(?:any\s+|the\s+)?(?:authority|permission)\s+to\b",
+    re.I,
+)
+
+def _has_action_before(proposition: str, end: int) -> bool:
+    """Return whether an independently recognizable action precedes ``end``."""
+    prefix = proposition[:end]
+    return any(re.search(pattern, prefix, flags=re.I | re.S) for pattern in ACTIVE_ACTION_PATTERNS)
+
 def _shared_governor(proposition: str) -> str | None:
     t = _norm(proposition)
     leading = re.match(r"^(?:[-*]\s*)?(never|do not|does not|must not|should not|may not|cannot|can't)\b", t)
@@ -158,8 +170,9 @@ def _shared_governor(proposition: str) -> str | None:
     if heading: return _norm(proposition[:heading.end() - len(heading.group(1))])
     denial = re.match(r"^(?:there (?:is no ordinary transition|are no ordinary transitions|is no authority|is no permission) to|no (?:ordinary transition|authority|permission) to)\b", t)
     if denial: return denial.group(0)
-    authority_denial = re.search(r"\b(?:never|does not|do not|cannot|can't)\s+(?:create|creates|grant|grants|provide|provides|confer|confers)\s+(?:any\s+|the\s+)?(?:authority|permission)\s+to\b", t)
-    if authority_denial: return authority_denial.group(0)
+    authority_denial = AUTHORITY_DENIAL.search(proposition)
+    if authority_denial and not _has_action_before(proposition, authority_denial.start()):
+        return _norm(authority_denial.group(0))
     if re.fullmatch(r"(?:no default role may be instantiated as an arbitrary external person\.\s*)?generic\s+`?reviewer`?,.*\bare invalid default research engine roles\.?", t): return "terminal invalid-role predicate"
     if re.fullmatch(r"migration passes only when .+\b(?:dependencies|paths|gates) must be zero\.?", t): return "terminal zero predicate"
     return None

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator
 
@@ -22,7 +22,7 @@ RESEARCH_LABOR_NOUN = r"(?:human\s+annotation|human\s+rating|human\s+coding|huma
 RESEARCH_WORK_VERB = r"(?:annotate|label|rate|score|code|review|classify|assess|evaluate)"
 ASSIGNMENT_VERB = r"(?:assign|hire|recruit|use|employ|contract|have)"
 ACTIVE_ACTION_PATTERNS = (
-    rf"\brecruit(?:ing|ed)?\b.{{0,60}}\b{HUMAN_TARGET}\b",
+    rf"\brecruit(?:ing|ed)?\b.{{0,60}}?\b{HUMAN_TARGET}\b",
     r"\b(?:participant|human|native[- ]speaker|speaker|respondent|expert)\s+recruitment\b",
     rf"\brecruitment\s+(?:of|for)\s+.{{0,40}}\b{HUMAN_TARGET}\b",
     rf"\bsurvey\b.{{0,50}}\b{HUMAN_TARGET}\b",
@@ -89,6 +89,9 @@ class ActionDisposition:
     source_item_end: int
     action_start: int
     action_end: int
+    semantic_action_index: int
+    semantic_action_start: int
+    semantic_action_end: int
     governor_scope_id: int | None
     governor: str | None
     disposition: str
@@ -107,10 +110,12 @@ class ActionOccurrence:
     source_item_text: str
     source_item_start: int
     source_item_end: int
+    semantic_action_index: int
     action: str
     action_start: int
     action_end: int
-    match: re.Match[str]
+    lexical_matches: tuple[re.Match[str], ...]
+    governor_scope_id: int | None = None
 
 @dataclass(frozen=True)
 class GovernorScope:
@@ -192,6 +197,11 @@ AUTHORITY_DENIAL = re.compile(
 ITEM_SEPARATOR = re.compile(r"\s*(?:,\s*(?:(?:and|or)\b\s*)?|\b(?:and|or)\b\s+)", re.I)
 LEADING_GOVERNOR = re.compile(r"^(?:[-*]\s*)?(?:never|do not|does not|must not|should not|may not|cannot|can't)\b\s*", re.I)
 NO_TRANSITION_GOVERNOR = re.compile(r"^(?:there (?:is no ordinary transition|are no ordinary transitions|is no authority|is no permission) to|no (?:ordinary transition|authority|permission) to)\b\s*", re.I)
+BARE_HUMAN_ACTION_MENTION = re.compile(
+    r"^(?:surveys?|interviews?|focus[ -]?groups?|(?:external\s+)?reviewer\s+approval|"
+    r"expert\s+panels?|human\s+validation)\.?$",
+    re.I,
+)
 
 def _source_action_items(proposition: str) -> list[SourceActionItem]:
     items: list[SourceActionItem] = []
@@ -212,7 +222,8 @@ def _source_action_items(proposition: str) -> list[SourceActionItem]:
     return items
 
 def _item_action_occurrences(item: SourceActionItem) -> list[ActionOccurrence]:
-    occurrences: list[ActionOccurrence] = []
+    """Group overlapping raw matches into deterministic semantic occurrences."""
+    raw_matches: list[re.Match[str]] = []
     seen: set[tuple[int, int]] = set()
     for pattern in ACTIVE_ACTION_PATTERNS:
         for match in re.finditer(pattern, item.source_item_text, flags=re.I | re.S):
@@ -220,11 +231,29 @@ def _item_action_occurrences(item: SourceActionItem) -> list[ActionOccurrence]:
             if key in seen:
                 continue
             seen.add(key)
-            occurrences.append(ActionOccurrence(
-                item.source_item_index, item.source_item_text, item.source_item_start, item.source_item_end,
-                match.group(0), item.source_item_start + match.start(), item.source_item_start + match.end(), match,
-            ))
-    return sorted(occurrences, key=lambda occurrence: (occurrence.action_start, occurrence.action_end))
+            raw_matches.append(match)
+    raw_matches.sort(key=lambda match: (match.start(), match.end()))
+    groups: list[list[re.Match[str]]] = []
+    for match in raw_matches:
+        if groups and match.start() == groups[-1][0].start():
+            groups[-1].append(match)
+        else:
+            groups.append([match])
+    occurrences: list[ActionOccurrence] = []
+    for semantic_action_index, matches in enumerate(groups):
+        if semantic_action_index + 1 < len(groups):
+            next_start = groups[semantic_action_index + 1][0].start()
+            matches = [match for match in matches if match.end() <= next_start]
+        if not matches:
+            continue
+        start = min(match.start() for match in matches)
+        end = max(match.end() for match in matches)
+        occurrences.append(ActionOccurrence(
+            item.source_item_index, item.source_item_text, item.source_item_start, item.source_item_end,
+            semantic_action_index, item.source_item_text[start:end], item.source_item_start + start,
+            item.source_item_start + end, tuple(matches),
+        ))
+    return occurrences
 
 def _governor_anchor(item: SourceActionItem) -> tuple[str, re.Match[str]] | None:
     candidates: list[tuple[str, re.Match[str]]] = []
@@ -241,12 +270,12 @@ def _governor_anchor(item: SourceActionItem) -> tuple[str, re.Match[str]] | None
         candidates.append(("authority_denial", authority))
     return min(candidates, key=lambda candidate: candidate[1].start()) if candidates else None
 
-def _resolve_governor_scopes(proposition: str) -> tuple[list[SourceActionItem], list[ActionOccurrence], list[GovernorScope], dict[int, int]]:
+def _resolve_governor_scopes(proposition: str) -> tuple[list[SourceActionItem], list[ActionOccurrence], list[GovernorScope], dict[tuple[int, int], int]]:
     """Resolve finite, contiguous scope before assigning lexical dispositions."""
     items = _source_action_items(proposition)
     by_item = {item.source_item_index: _item_action_occurrences(item) for item in items}
     scopes: list[GovernorScope] = []
-    membership: dict[int, int] = {}
+    membership: dict[tuple[int, int], int] = {}
     active_scope: int | None = None
     for item in items:
         occurrences = by_item[item.source_item_index]
@@ -258,24 +287,31 @@ def _resolve_governor_scopes(proposition: str) -> tuple[list[SourceActionItem], 
             active_scope = None
             if governed_occurrences:
                 scope_id = len(scopes)
+                governed_occurrence = governed_occurrences[0]
                 scopes.append(GovernorScope(scope_id, kind, match.group(0).strip(),
                     item.source_item_start + match.start(), item.source_item_start + match.end(),
-                    governed_start, item.source_item_end))
-                membership[item.source_item_index] = scope_id
-                active_scope = scope_id
+                    governed_start, governed_occurrence.action_end))
+                membership[(item.source_item_index, governed_occurrence.semantic_action_index)] = scope_id
+                active_scope = scope_id if len(governed_occurrences) == 1 else None
             continue
-        if active_scope is not None and not occurrences:
-            # A decomposition fragment with no recognized source action has no
-            # item-level membership to grant or deny and cannot create ACTIVE.
-            continue
-        if active_scope is not None and occurrences[0].action_start == item.source_item_start:
-            membership[item.source_item_index] = active_scope
+        if active_scope is not None and occurrences and occurrences[0].action_start == item.source_item_start:
+            occurrence = occurrences[0]
+            membership[(item.source_item_index, occurrence.semantic_action_index)] = active_scope
             scope = scopes[active_scope]
             scopes[active_scope] = GovernorScope(scope.scope_id, scope.governor_kind, scope.governor_text,
-                scope.governor_start, scope.governor_end, scope.governed_start, item.source_item_end)
+                scope.governor_start, scope.governor_end, scope.governed_start, occurrence.action_end)
+            if len(occurrences) > 1:
+                active_scope = None
+        elif active_scope is not None and BARE_HUMAN_ACTION_MENTION.fullmatch(item.source_item_text):
+            # Some bounded list nouns are governed human-action mentions but
+            # deliberately do not create an ACTIVE action disposition alone.
+            continue
         else:
             active_scope = None
-    return items, [occurrence for item in items for occurrence in by_item[item.source_item_index]], scopes, membership
+    occurrences = [occurrence for item in items for occurrence in by_item[item.source_item_index]]
+    occurrences = [replace(occurrence, governor_scope_id=membership.get(
+        (occurrence.source_item_index, occurrence.semantic_action_index))) for occurrence in occurrences]
+    return items, occurrences, scopes, membership
 
 def _shared_governor(proposition: str) -> str | None:
     """Compatibility signal only; disposition authority lives in GovernorScope."""
@@ -309,16 +345,22 @@ def _action_dispositions(proposition: str, proposition_id: int) -> list[ActionDi
     _, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
     decisions = []
     for occurrence in occurrences:
-        scope_id = membership.get(occurrence.source_item_index)
+        occurrence_key = (occurrence.source_item_index, occurrence.semantic_action_index)
+        scope_id = membership.get(occurrence_key)
         scope = scopes[scope_id] if scope_id is not None else None
-        local = _local_non_active(occurrence.source_item_text, occurrence.match)
-        reason = scope.governor_text if scope else local
-        decisions.append(ActionDisposition(
-            occurrence.action, proposition_id, occurrence.source_item_index, occurrence.source_item_text,
-            occurrence.source_item_start, occurrence.source_item_end, occurrence.action_start, occurrence.action_end,
-            scope_id, scope.governor_text if scope else None, "NON_ACTIVE" if reason else "ACTIVE",
-            reason or "no supported non-active scope",
-        ))
+        item = SourceActionItem(occurrence.source_item_index, occurrence.source_item_text,
+            occurrence.source_item_start, occurrence.source_item_end)
+        for match in occurrence.lexical_matches:
+            local = None if _governor_anchor(item) else _local_non_active(occurrence.source_item_text, match)
+            reason = scope.governor_text if scope else local
+            decisions.append(ActionDisposition(
+                match.group(0), proposition_id, occurrence.source_item_index, occurrence.source_item_text,
+                occurrence.source_item_start, occurrence.source_item_end,
+                occurrence.source_item_start + match.start(), occurrence.source_item_start + match.end(),
+                occurrence.semantic_action_index, occurrence.action_start, occurrence.action_end,
+                scope_id, scope.governor_text if scope else None, "NON_ACTIVE" if reason else "ACTIVE",
+                reason or "no supported non-active scope",
+            ))
     return decisions
 
 def _clause_has_static_source(clause: str) -> bool: return any(re.search(p,clause,flags=re.I) for p in STATIC_SOURCE_PATTERNS)

--- a/tools/research_policy.py
+++ b/tools/research_policy.py
@@ -85,9 +85,42 @@ class ActionDisposition:
     proposition_id: int
     source_item_index: int
     source_item_text: str
+    source_item_start: int
+    source_item_end: int
+    action_start: int
+    action_end: int
+    governor_scope_id: int | None
     governor: str | None
     disposition: str
     reason: str
+
+@dataclass(frozen=True)
+class SourceActionItem:
+    source_item_index: int
+    source_item_text: str
+    source_item_start: int
+    source_item_end: int
+
+@dataclass(frozen=True)
+class ActionOccurrence:
+    source_item_index: int
+    source_item_text: str
+    source_item_start: int
+    source_item_end: int
+    action: str
+    action_start: int
+    action_end: int
+    match: re.Match[str]
+
+@dataclass(frozen=True)
+class GovernorScope:
+    scope_id: int
+    governor_kind: str
+    governor_text: str
+    governor_start: int
+    governor_end: int
+    governed_start: int
+    governed_end: int
 
 def _policy_units(text: str) -> list[str]:
     """Assemble bounded Markdown structures without treating soft wraps as scope."""
@@ -156,59 +189,107 @@ AUTHORITY_DENIAL = re.compile(
     r"(?:any\s+|the\s+)?(?:authority|permission)\s+to\b",
     re.I,
 )
+ITEM_SEPARATOR = re.compile(r"\s*(?:,\s*(?:(?:and|or)\b\s*)?|\b(?:and|or)\b\s+)", re.I)
+LEADING_GOVERNOR = re.compile(r"^(?:[-*]\s*)?(?:never|do not|does not|must not|should not|may not|cannot|can't)\b\s*", re.I)
+NO_TRANSITION_GOVERNOR = re.compile(r"^(?:there (?:is no ordinary transition|are no ordinary transitions|is no authority|is no permission) to|no (?:ordinary transition|authority|permission) to)\b\s*", re.I)
 
-def _has_action_before(proposition: str, end: int) -> bool:
-    """Return whether an independently recognizable action precedes ``end``."""
-    prefix = proposition[:end]
-    return any(re.search(pattern, prefix, flags=re.I | re.S) for pattern in ACTIVE_ACTION_PATTERNS)
+def _source_action_items(proposition: str) -> list[SourceActionItem]:
+    items: list[SourceActionItem] = []
+    start = 0
+    for separator in ITEM_SEPARATOR.finditer(proposition):
+        raw_start, raw_end = start, separator.start()
+        start = separator.end()
+        left = len(proposition[raw_start:raw_end]) - len(proposition[raw_start:raw_end].lstrip())
+        right = len(proposition[raw_start:raw_end].rstrip())
+        if right > left:
+            item_start, item_end = raw_start + left, raw_start + right
+            items.append(SourceActionItem(len(items), proposition[item_start:item_end], item_start, item_end))
+    raw = proposition[start:]
+    left, right = len(raw) - len(raw.lstrip()), len(raw.rstrip())
+    if right > left:
+        item_start, item_end = start + left, start + right
+        items.append(SourceActionItem(len(items), proposition[item_start:item_end], item_start, item_end))
+    return items
+
+def _item_action_occurrences(item: SourceActionItem) -> list[ActionOccurrence]:
+    occurrences: list[ActionOccurrence] = []
+    seen: set[tuple[int, int]] = set()
+    for pattern in ACTIVE_ACTION_PATTERNS:
+        for match in re.finditer(pattern, item.source_item_text, flags=re.I | re.S):
+            key = (match.start(), match.end())
+            if key in seen:
+                continue
+            seen.add(key)
+            occurrences.append(ActionOccurrence(
+                item.source_item_index, item.source_item_text, item.source_item_start, item.source_item_end,
+                match.group(0), item.source_item_start + match.start(), item.source_item_start + match.end(), match,
+            ))
+    return sorted(occurrences, key=lambda occurrence: (occurrence.action_start, occurrence.action_end))
+
+def _governor_anchor(item: SourceActionItem) -> tuple[str, re.Match[str]] | None:
+    candidates: list[tuple[str, re.Match[str]]] = []
+    for kind, pattern in (("leading_negation", LEADING_GOVERNOR), ("no_transition", NO_TRANSITION_GOVERNOR)):
+        match = pattern.search(item.source_item_text)
+        if match:
+            candidates.append((kind, match))
+    heading = POLICY_HEADING.match(item.source_item_text)
+    if heading:
+        anchor_end = heading.end() - len(heading.group(1))
+        candidates.append(("policy_heading", re.match(rf"^.{{{anchor_end}}}", item.source_item_text, re.S)))
+    authority = AUTHORITY_DENIAL.search(item.source_item_text)
+    if authority:
+        candidates.append(("authority_denial", authority))
+    return min(candidates, key=lambda candidate: candidate[1].start()) if candidates else None
+
+def _resolve_governor_scopes(proposition: str) -> tuple[list[SourceActionItem], list[ActionOccurrence], list[GovernorScope], dict[int, int]]:
+    """Resolve finite, contiguous scope before assigning lexical dispositions."""
+    items = _source_action_items(proposition)
+    by_item = {item.source_item_index: _item_action_occurrences(item) for item in items}
+    scopes: list[GovernorScope] = []
+    membership: dict[int, int] = {}
+    active_scope: int | None = None
+    for item in items:
+        occurrences = by_item[item.source_item_index]
+        anchor = _governor_anchor(item)
+        if anchor is not None:
+            kind, match = anchor
+            governed_start = item.source_item_start + match.end()
+            governed_occurrences = [occurrence for occurrence in occurrences if occurrence.action_start >= governed_start]
+            active_scope = None
+            if governed_occurrences:
+                scope_id = len(scopes)
+                scopes.append(GovernorScope(scope_id, kind, match.group(0).strip(),
+                    item.source_item_start + match.start(), item.source_item_start + match.end(),
+                    governed_start, item.source_item_end))
+                membership[item.source_item_index] = scope_id
+                active_scope = scope_id
+            continue
+        if active_scope is not None and not occurrences:
+            # A decomposition fragment with no recognized source action has no
+            # item-level membership to grant or deny and cannot create ACTIVE.
+            continue
+        if active_scope is not None and occurrences[0].action_start == item.source_item_start:
+            membership[item.source_item_index] = active_scope
+            scope = scopes[active_scope]
+            scopes[active_scope] = GovernorScope(scope.scope_id, scope.governor_kind, scope.governor_text,
+                scope.governor_start, scope.governor_end, scope.governed_start, item.source_item_end)
+        else:
+            active_scope = None
+    return items, [occurrence for item in items for occurrence in by_item[item.source_item_index]], scopes, membership
 
 def _shared_governor(proposition: str) -> str | None:
+    """Compatibility signal only; disposition authority lives in GovernorScope."""
+    items, _, scopes, _ = _resolve_governor_scopes(proposition)
+    if scopes:
+        return scopes[0].governor_text
+    for item in items:
+        anchor = _governor_anchor(item)
+        if anchor:
+            return anchor[1].group(0).strip()
     t = _norm(proposition)
-    leading = re.match(r"^(?:[-*]\s*)?(never|do not|does not|must not|should not|may not|cannot|can't)\b", t)
-    if leading: return leading.group(1)
-    heading = POLICY_HEADING.match(proposition)
-    if heading: return _norm(proposition[:heading.end() - len(heading.group(1))])
-    denial = re.match(r"^(?:there (?:is no ordinary transition|are no ordinary transitions|is no authority|is no permission) to|no (?:ordinary transition|authority|permission) to)\b", t)
-    if denial: return denial.group(0)
-    authority_denial = AUTHORITY_DENIAL.search(proposition)
-    if authority_denial and not _has_action_before(proposition, authority_denial.start()):
-        return _norm(authority_denial.group(0))
     if re.fullmatch(r"(?:no default role may be instantiated as an arbitrary external person\.\s*)?generic\s+`?reviewer`?,.*\bare invalid default research engine roles\.?", t): return "terminal invalid-role predicate"
     if re.fullmatch(r"migration passes only when .+\b(?:dependencies|paths|gates) must be zero\.?", t): return "terminal zero predicate"
     return None
-
-def _source_item_text(item: str, source_item_index: int, governor: str | None) -> str:
-    if source_item_index != 0 or governor is None:
-        return item.strip()
-    heading = POLICY_HEADING.match(item)
-    if heading:
-        return heading.group(1).strip()
-    governed_prefix = re.compile(
-        r"^\s*(?:(?:never|do\s+not|does\s+not|must\s+not|should\s+not|may\s+not|cannot|can't)\b|"
-        r"(?:there\s+(?:is\s+no\s+ordinary\s+transition|are\s+no\s+ordinary\s+transitions|is\s+no\s+authority|is\s+no\s+permission)\s+to|"
-        r"no\s+(?:ordinary\s+transition|authority|permission)\s+to)\b)\s*",
-        re.I,
-    )
-    return governed_prefix.sub("", item, count=1).strip()
-
-def _action_matches(proposition: str) -> Iterator[tuple[int, str, re.Match[str]]]:
-    """Decompose action items only after proposition scope is resolved.
-
-    Coordination is a lexical item delimiter here, never evidence for or against
-    shared scope.  Returning the item alongside its match keeps broad legacy
-    recognizers from consuming a separately disposable neighboring action.
-    """
-    items = re.split(r"\s*,\s*|\s+\b(?:and|or)\b\s+", proposition, flags=re.I)
-    governor = _shared_governor(proposition)
-    for source_item_index, item in enumerate(items):
-        source_item_text = _source_item_text(item, source_item_index, governor)
-        seen: set[tuple[int, int]] = set()
-        for pattern in ACTIVE_ACTION_PATTERNS:
-            for match in re.finditer(pattern, source_item_text, flags=re.I | re.S):
-                key = (match.start(), match.end())
-                if key not in seen:
-                    seen.add(key)
-                    yield source_item_index, source_item_text, match
 
 def _local_non_active(proposition: str, match: re.Match[str]) -> str | None:
     before = proposition[:match.start()].lower()[-100:]
@@ -222,12 +303,22 @@ def _local_non_active(proposition: str, match: re.Match[str]) -> str | None:
     return None
 
 def _action_dispositions(proposition: str, proposition_id: int) -> list[ActionDisposition]:
-    governor = _shared_governor(proposition)
+    t = _norm(proposition)
+    if re.fullmatch(r"(?:no default role may be instantiated as an arbitrary external person\.\s*)?generic\s+`?reviewer`?,.*\bare invalid default research engine roles\.?", t) or re.fullmatch(r"migration passes only when .+\b(?:dependencies|paths|gates) must be zero\.?", t):
+        return []
+    _, occurrences, scopes, membership = _resolve_governor_scopes(proposition)
     decisions = []
-    for source_item_index, source_item_text, match in _action_matches(proposition):
-        local = _local_non_active(source_item_text, match)
-        reason = governor or local
-        decisions.append(ActionDisposition(match.group(0), proposition_id, source_item_index, source_item_text, governor, "NON_ACTIVE" if reason else "ACTIVE", reason or "no supported non-active scope"))
+    for occurrence in occurrences:
+        scope_id = membership.get(occurrence.source_item_index)
+        scope = scopes[scope_id] if scope_id is not None else None
+        local = _local_non_active(occurrence.source_item_text, occurrence.match)
+        reason = scope.governor_text if scope else local
+        decisions.append(ActionDisposition(
+            occurrence.action, proposition_id, occurrence.source_item_index, occurrence.source_item_text,
+            occurrence.source_item_start, occurrence.source_item_end, occurrence.action_start, occurrence.action_end,
+            scope_id, scope.governor_text if scope else None, "NON_ACTIVE" if reason else "ACTIVE",
+            reason or "no supported non-active scope",
+        ))
     return decisions
 
 def _clause_has_static_source(clause: str) -> bool: return any(re.search(p,clause,flags=re.I) for p in STATIC_SOURCE_PATTERNS)


### PR DESCRIPTION
### Motivation

- Fix a defect where an authority-denial phrase appearing later in a proposition could be applied as a proposition-level shared governor and retroactively suppress an earlier independent ACTIVE source action.
- Preserve existing prefix-led shared-governor behavior and all R1 semantic invariants while preventing trailing denials from changing earlier source-item dispositions.

### Description

- Add a bounded authority-denial recognizer `AUTHORITY_DENIAL` and a helper ` _has_action_before(proposition, end)` that tests whether an independently recognizable action occurs before a denial.
- Modify `_shared_governor` so an authority-denial only becomes a proposition-wide governor when no independent human-action pattern appears to its left; trailing denials continue to provide local `NON_ACTIVE` evidence but no longer retroactively govern left-side actions.
- Add tests exercising direct mixed cases, subject-led prefix denial controls, a generated trailing-denial matrix, multi-action preceding scenarios, and soft-wrap/layout variants to validate the invariant and preserve existing behaviors.

### Testing

- Ran the targeted policy tests with `python -m unittest -v tests.test_research_machine_only` (34 tests) and observed a passing run; `ACTIVE_DEPENDENCY` / `EXPLICIT_PROHIBITION` behaviors for mixed/trailing cases were validated.
- Ran the full test suite with `python -m unittest discover -s tests -p 'test*.py'` (80 tests) and observed all tests passed (`OK`).
- Executed repository validators `python tools/research_policy.py --repo`, `python tools/validate_structure.py`, and `python -m py_compile tools/research_policy.py`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97449a44b88320b6959699fa5eb244)