### PR TITLE
Add thin resolver/spawn entrypoint (tools/resolver_spawn.py) with integration tests

### DIFF
--- a/tests/test_resolver_spawn.py
+++ b/tests/test_resolver_spawn.py
@@ -7,9 +7,11 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from tests.test_assignment_compiler import action, claim, draft, envelope
 from tests.test_executability import governed_chain, valid_chain
+import tools.resolver_spawn as resolver_spawn
 from tools.resolver_spawn import resolve_spawn
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -117,6 +119,49 @@ class ResolverSpawnTest(unittest.TestCase):
         value = bundle(); value["selected_prerequisite_actions"] = [{"action_id": "test", "required_capabilities": ["shell"], "evidence_path": None}]
         result = resolve_spawn(value)
         self.assertEqual(result["reason"], "CONTRADICTORY_CONTROL_ARTIFACTS")
+
+    def test_malformed_profile_or_route_ref_escalates_without_exception(self):
+        for field, bad_value in (("capability_profile_ref", []), ("route_ref", {})):
+            with self.subTest(field=field):
+                value = bundle(); value[field] = bad_value
+                result = resolve_spawn(value)
+                self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "MALFORMED_CONTROL_ARTIFACT"))
+                self.assertNotIn("assignment", result)
+
+    def test_duplicate_artifact_identity_fails_closed(self):
+        value = bundle(); value["artifacts"].append(deepcopy(value["artifacts"][2]))
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "CONTRADICTORY_CONTROL_ARTIFACTS"))
+        self.assertTrue(any("duplicate artifact_id" in error for error in result["errors"]))
+
+    def test_compiled_capability_drop_is_caught_by_full_proof(self):
+        value = bundle()
+        real_compile = resolver_spawn.compile_assignment
+
+        def compile_with_extra_capability(*args, **kwargs):
+            compiled = real_compile(*args, **kwargs)
+            compiled["authorized_required_capabilities"] = sorted(set(compiled["authorized_required_capabilities"]) | {"database_access"})
+            return compiled
+
+        with patch.object(resolver_spawn, "compile_assignment", side_effect=compile_with_extra_capability), \
+             patch.object(resolver_spawn, "validate_compiled_assignment", return_value=[]):
+            result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "FINAL_ASSIGNMENT_PROOF_FAILED"))
+        self.assertTrue(any("drops compiled assignment capabilities" in error for error in result["errors"]))
+
+    def test_final_assignment_ref_mismatch_is_caught_by_full_proof(self):
+        value = bundle()
+        real_proof = resolver_spawn.validate_assignment_execution_contract
+
+        def validate_with_bad_ref(assignment, *args, **kwargs):
+            mutated = deepcopy(assignment)
+            mutated["execution_contract"]["admissibility_ref"] = "ADM-WRONG"
+            return real_proof(mutated, *args, **kwargs)
+
+        with patch.object(resolver_spawn, "validate_assignment_execution_contract", side_effect=validate_with_bad_ref):
+            result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "FINAL_ASSIGNMENT_PROOF_FAILED"))
+        self.assertTrue(any("admissibility_ref mismatch" in error for error in result["errors"]))
 
     def test_cli_reads_only_local_json_and_emits_json(self):
         value = bundle()

--- a/tests/test_resolver_spawn.py
+++ b/tests/test_resolver_spawn.py
@@ -59,6 +59,12 @@ class ResolverSpawnTest(unittest.TestCase):
             with self.subTest(engine=value["decision"]["engine_id"]):
                 self.assert_spawn_ready(value)
 
+    def test_research_requires_structured_machine_only_admission(self):
+        value = bundle("research", "execute_research_work", "machine-only-execution")
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "RESEARCH_ADMISSION_REQUIRED"))
+        self.assertNotIn("assignment", result)
+
     def test_compilation_rejected_escalates_without_assignment(self):
         value = bundle(); value["assignment_compilation_draft"]["mandatory_actions"][0]["claim_ref"] = "missing"
         result = resolve_spawn(value)
@@ -72,6 +78,18 @@ class ResolverSpawnTest(unittest.TestCase):
         self.assertEqual((result["control_state"], result["reason"]), ("WAIT", "ASSIGNMENT_NOT_ADMISSIBLE"))
         self.assertEqual(result["missing_capabilities"], ["database_access"])
         self.assertNotIn("assignment", result)
+
+    def test_control_obligation_capability_does_not_expand_executor_destination(self):
+        value = bundle()
+        value["assignment_compilation_draft"]["authorized_claims"].append(
+            claim("control-outcome", responsibility="CONTROL")
+        )
+        value["assignment_compilation_draft"]["mandatory_actions"].append(
+            action("owner-check", claim_ref="control-outcome", responsibility="CONTROL", capabilities=["owner_authority"])
+        )
+        result = self.assert_spawn_ready(value)
+        self.assertNotIn("owner_authority", result["assignment_admissibility"]["required_capabilities"])
+        self.assertFalse(any(item.get("action_id") == "owner-check" for item in result["assignment_admissibility"]["mandatory_actions"]))
 
     def test_stale_profile_waits_but_malformed_profile_escalates(self):
         stale = bundle(); profile = stale["artifacts"][2]
@@ -162,6 +180,14 @@ class ResolverSpawnTest(unittest.TestCase):
             result = resolve_spawn(value)
         self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "FINAL_ASSIGNMENT_PROOF_FAILED"))
         self.assertTrue(any("admissibility_ref mismatch" in error for error in result["errors"]))
+
+    def test_malformed_final_capability_entry_escalates_without_exception(self):
+        value = bundle()
+        value["assignment_compilation_draft"]["mandatory_actions"][0]["required_capabilities"] = [5]
+        value["assignment_compilation_draft"]["authorized_required_capabilities"] = []
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "MALFORMED_MANDATORY_ACTION"))
+        self.assertNotIn("assignment", result)
 
     def test_cli_reads_only_local_json_and_emits_json(self):
         value = bundle()

--- a/tests/test_resolver_spawn.py
+++ b/tests/test_resolver_spawn.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from tests.test_assignment_compiler import action, claim, draft, envelope
+from tests.test_executability import governed_chain, valid_chain
+from tools.resolver_spawn import resolve_spawn
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def bundle(engine="production/software", capability="implement_software_change", workflow="implementation"):
+    assignment, _, profile = deepcopy(valid_chain())
+    _, route = governed_chain(assignment, {}, profile)
+    compilation = draft("MOVING_BRANCH")
+    compilation["mandatory_actions"] = [action(capabilities=["python_runtime", "shell"])]
+    compilation["authorized_required_capabilities"] = ["python_runtime", "shell"]
+    env = envelope()
+    evidence = profile["evidence_artifacts"][0]
+    return {
+        "decision": {"control_state": "ASSIGN", "engine_id": engine, "engine_status": "available",
+                     "semantic_capability": capability, "workflow_id": workflow, "execution_mode": "local"},
+        "assignment_compilation_draft": compilation,
+        "assignment_draft_semantics": {"objective": "Perform the already-authorized bounded work.", "authority": ["OWNER/K0"],
+            "scope": {"allowed": ["bounded work"], "forbidden": ["scope expansion"]}, "acceptance": ["produce required evidence"],
+            "required_outputs": ["result"], "stop_conditions": ["runtime drift"], "result_to": "agent-1"},
+        "selected_prerequisite_actions": [], "execution_envelope_ref": env["artifact_id"],
+        "capability_profile_ref": profile["artifact_id"], "route_ref": route["artifact_id"],
+        "admissibility_id": "ADM-RESOLVED", "assignment_id": "ASSIGN-RESOLVED",
+        "artifacts": [env, evidence, profile, route],
+    }
+
+
+class ResolverSpawnTest(unittest.TestCase):
+    def assert_spawn_ready(self, value):
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["status"]), ("ASSIGN", "SPAWN_READY"), result)
+        self.assertEqual(result["assignment"]["objective"], value["assignment_draft_semantics"]["objective"])
+        return result
+
+    def test_representative_software_research_and_verification(self):
+        cases = [
+            bundle(),
+            bundle("research", "execute_research_work", "machine-only-execution"),
+            bundle("verification", "verify_completion_claim", "exact-evidence-verification"),
+        ]
+        cases[1]["decision"]["research_admission"] = "MACHINE_ONLY_ADMITTED"
+        cases[2]["assignment_compilation_draft"]["evidence_requirements"] = [
+            action("verification-evidence", capabilities=["python_runtime"], obligation_class="local_evidence")]
+        for value in cases:
+            with self.subTest(engine=value["decision"]["engine_id"]):
+                self.assert_spawn_ready(value)
+
+    def test_compilation_rejected_escalates_without_assignment(self):
+        value = bundle(); value["assignment_compilation_draft"]["mandatory_actions"][0]["claim_ref"] = "missing"
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "COMPILE_REJECTED"))
+        self.assertNotIn("assignment", result)
+
+    def test_missing_capability_waits_with_subset_details(self):
+        value = bundle(); value["assignment_compilation_draft"]["mandatory_actions"][0]["required_capabilities"].append("database_access")
+        value["assignment_compilation_draft"]["authorized_required_capabilities"].append("database_access")
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("WAIT", "ASSIGNMENT_NOT_ADMISSIBLE"))
+        self.assertEqual(result["missing_capabilities"], ["database_access"])
+        self.assertNotIn("assignment", result)
+
+    def test_stale_profile_waits_but_malformed_profile_escalates(self):
+        stale = bundle(); profile = stale["artifacts"][2]
+        profile["freshness_boundary"]["observed_at"] = "2024-01-01T00:00:00Z"
+        profile["freshness_boundary"]["valid_until"] = "2025-01-01T00:00:00Z"
+        profile["evidence_artifacts"][0]["observed_at"] = "2024-01-01T00:00:00Z"
+        profile["evidence_artifacts"][0]["valid_until"] = "2025-01-01T00:00:00Z"
+        stale["artifacts"][1]["observed_at"] = "2024-01-01T00:00:00Z"
+        stale["artifacts"][1]["valid_until"] = "2025-01-01T00:00:00Z"
+        result = resolve_spawn(stale)
+        self.assertEqual((result["control_state"], result["reason"]), ("WAIT", "CAPABILITY_PROFILE_STALE"))
+        malformed = bundle(); del malformed["artifacts"][2]["destination_id"]
+        result = resolve_spawn(malformed)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "MALFORMED_CAPABILITY_PROFILE"))
+
+    def test_route_profile_destination_mismatch_escalates(self):
+        value = bundle(); value["artifacts"][3]["segments"][1]["destination_id"] = "other"
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "EXECUTION_ROUTE_INVALID"))
+
+    def test_prerequisite_action_is_accounted_and_bare_capability_is_rejected(self):
+        value = bundle(); value["selected_prerequisite_actions"] = [{"action_id": "render", "required_capabilities": ["shell"], "evidence_path": "render-check"}]
+        result = self.assert_spawn_ready(value)
+        self.assertIn("render-check", result["assignment_admissibility"]["mandatory_evidence_paths"])
+        value = bundle(); value["additional_required_capabilities"] = ["outbound_network"]
+        result = resolve_spawn(value)
+        self.assertEqual(result["reason"], "UNACCOUNTED_CAPABILITY_EXPANSION")
+
+    def test_non_materialized_engine_and_terminal_batons(self):
+        value = bundle("canon", "reconcile_canon", "none"); value["decision"]["engine_status"] = "not_materialized"
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "ENGINE_NOT_MATERIALIZED"))
+        for state in ("WAIT", "ESCALATE", "COMPLETE"):
+            value = bundle(); value["decision"]["control_state"] = state
+            result = resolve_spawn(value)
+            self.assertEqual((result["control_state"], result["status"]), (state, state))
+            self.assertNotIn("assignment", result)
+
+    def test_missing_semantics_fail_closed(self):
+        value = bundle(); del value["assignment_draft_semantics"]["objective"]
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "MISSING_ASSIGNMENT_SEMANTICS"))
+
+    def test_duplicate_action_identity_fails_closed(self):
+        value = bundle(); value["selected_prerequisite_actions"] = [{"action_id": "test", "required_capabilities": ["shell"], "evidence_path": None}]
+        result = resolve_spawn(value)
+        self.assertEqual(result["reason"], "CONTRADICTORY_CONTROL_ARTIFACTS")
+
+    def test_cli_reads_only_local_json_and_emits_json(self):
+        value = bundle()
+        with tempfile.NamedTemporaryFile("w", suffix=".json", encoding="utf-8") as handle:
+            json.dump(value, handle); handle.flush()
+            completed = subprocess.run([sys.executable, str(ROOT / "tools/resolver_spawn.py"), handle.name], check=True, text=True, capture_output=True)
+        self.assertEqual(json.loads(completed.stdout)["status"], "SPAWN_READY")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/resolver_spawn.py
+++ b/tools/resolver_spawn.py
@@ -93,6 +93,8 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     if decision["engine_status"] != "available":
         reason = "ENGINE_NOT_MATERIALIZED" if decision["engine_status"] == "not_materialized" else "ENGINE_UNAVAILABLE"
         return _out("ESCALATE", reason, engine_id=decision["engine_id"])
+    if decision["engine_id"] == "research" and decision.get("research_admission") != "MACHINE_ONLY_ADMITTED":
+        return _out("ESCALATE", "RESEARCH_ADMISSION_REQUIRED", engine_id=decision["engine_id"])
     if "additional_required_capabilities" in control_bundle or "final_required_capabilities" in control_bundle:
         return _out("ESCALATE", "UNACCOUNTED_CAPABILITY_EXPANSION")
 
@@ -120,9 +122,22 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     prerequisites, prerequisite_errors = _valid_prerequisites(control_bundle.get("selected_prerequisite_actions", []))
     if prerequisite_errors:
         return _out("ESCALATE", "MALFORMED_PREREQUISITE_ACTION", errors=prerequisite_errors)
-    compiled_actions = deepcopy(compiled["authorized_mandatory_actions"])
-    compiled_evidence = deepcopy(compiled["authorized_evidence_requirements"])
+    compiled_actions = [
+        deepcopy(item) for item in compiled["authorized_mandatory_actions"]
+        if isinstance(item, Mapping) and item.get("responsibility") == "EXECUTOR"
+    ]
+    compiled_evidence = [
+        deepcopy(item) for item in compiled["authorized_evidence_requirements"]
+        if isinstance(item, Mapping) and item.get("responsibility") == "EXECUTOR"
+    ]
     final_actions = compiled_actions + compiled_evidence + prerequisites
+    capability_errors = []
+    for index, action in enumerate(final_actions):
+        capabilities = action.get("required_capabilities")
+        if not isinstance(capabilities, list) or not all(isinstance(cap, str) and cap.strip() for cap in capabilities):
+            capability_errors.append(f"final mandatory action[{index}].required_capabilities must be a string list")
+    if capability_errors:
+        return _out("ESCALATE", "MALFORMED_MANDATORY_ACTION", errors=capability_errors)
     action_ids = [item.get("action_id") for item in final_actions if isinstance(item, Mapping)]
     if len(action_ids) != len(set(action_ids)):
         return _out("ESCALATE", "CONTRADICTORY_CONTROL_ARTIFACTS", errors=["duplicate final mandatory action id"])

--- a/tools/resolver_spawn.py
+++ b/tools/resolver_spawn.py
@@ -30,11 +30,23 @@ def _out(control_state: str, reason: str, **details: object) -> dict[str, object
 
 
 def _artifact_resolver(artifacts: object):
-    by_id = {
-        item["artifact_id"]: item for item in artifacts if isinstance(item, Mapping)
-        and isinstance(item.get("artifact_id"), str)
-    } if isinstance(artifacts, list) else {}
-    return by_id.get, by_id
+    if not isinstance(artifacts, list):
+        return None, {}, ["artifacts must be a list"]
+    by_id: dict[str, Mapping[str, object]] = {}
+    errors: list[str] = []
+    for index, item in enumerate(artifacts):
+        if not isinstance(item, Mapping):
+            errors.append(f"artifacts[{index}] must be an object")
+            continue
+        artifact_id = item.get("artifact_id")
+        if not isinstance(artifact_id, str) or not artifact_id.strip():
+            errors.append(f"artifacts[{index}].artifact_id must be a non-empty string")
+            continue
+        if artifact_id in by_id:
+            errors.append(f"duplicate artifact_id: {artifact_id}")
+            continue
+        by_id[artifact_id] = item
+    return by_id.get, by_id, errors
 
 
 def _profile_is_only_stale(errors: list[str]) -> bool:
@@ -84,7 +96,10 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     if "additional_required_capabilities" in control_bundle or "final_required_capabilities" in control_bundle:
         return _out("ESCALATE", "UNACCOUNTED_CAPABILITY_EXPANSION")
 
-    resolver, artifacts = _artifact_resolver(control_bundle.get("artifacts", []))
+    resolver, artifacts, artifact_errors = _artifact_resolver(control_bundle.get("artifacts", []))
+    if artifact_errors:
+        reason = "CONTRADICTORY_CONTROL_ARTIFACTS" if any(error.startswith("duplicate artifact_id:") for error in artifact_errors) else "MALFORMED_CONTROL_ARTIFACT"
+        return _out("ESCALATE", reason, errors=artifact_errors)
     draft = control_bundle.get("assignment_compilation_draft")
     semantics = control_bundle.get("assignment_draft_semantics")
     if not isinstance(draft, Mapping) or not isinstance(semantics, Mapping):
@@ -93,7 +108,7 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     if missing_semantics:
         return _out("ESCALATE", "MISSING_ASSIGNMENT_SEMANTICS", errors=missing_semantics)
     envelope_ref = control_bundle.get("execution_envelope_ref")
-    compiled = compile_assignment(draft, envelope_ref, resolver, resolver) if isinstance(envelope_ref, str) else None
+    compiled = compile_assignment(draft, envelope_ref, resolver, resolver) if isinstance(envelope_ref, str) and envelope_ref.strip() else None
     if compiled is None:
         return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT", errors=["execution_envelope_ref is required"])
     if compiled.get("compilation_status") != "COMPILED":
@@ -115,6 +130,12 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     paths = sorted({path for action in final_actions if isinstance((path := action.get("evidence_path")), str) and path.strip()})
 
     profile_ref, route_ref = control_bundle.get("capability_profile_ref"), control_bundle.get("route_ref")
+    invalid_refs = [
+        field for field, value in (("capability_profile_ref", profile_ref), ("route_ref", route_ref))
+        if not isinstance(value, str) or not value.strip()
+    ]
+    if invalid_refs:
+        return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT", errors=[f"{field} must be a non-empty string" for field in invalid_refs])
     profile, route = artifacts.get(profile_ref), artifacts.get(route_ref)
     if not isinstance(profile, Mapping) or not isinstance(route, Mapping):
         return _out("ESCALATE", "REFERENCE_IDENTITY_MISMATCH")

--- a/tools/resolver_spawn.py
+++ b/tools/resolver_spawn.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Thin, bundle-local composition of governed pre-spawn control artifacts."""
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from copy import deepcopy
+import json
+from pathlib import Path
+import sys
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.assignment_compiler import compile_assignment, validate_compiled_assignment
+from tools.executability import (
+    evaluate_assignment_admissibility,
+    validate_admissibility_against_profile,
+    validate_assignment_execution_contract,
+    validate_capability_profile,
+    validate_execution_route,
+)
+
+TERMINAL_STATES = {"WAIT", "ESCALATE", "COMPLETE"}
+SEMANTIC_FIELDS = ("objective", "authority", "scope", "acceptance", "stop_conditions", "result_to")
+
+
+def _out(control_state: str, reason: str, **details: object) -> dict[str, object]:
+    return {"status": control_state, "control_state": control_state, "reason": reason, **details}
+
+
+def _artifact_resolver(artifacts: object):
+    by_id = {
+        item["artifact_id"]: item for item in artifacts if isinstance(item, Mapping)
+        and isinstance(item.get("artifact_id"), str)
+    } if isinstance(artifacts, list) else {}
+    return by_id.get, by_id
+
+
+def _profile_is_only_stale(errors: list[str]) -> bool:
+    """Classify freshness failures already reported by the authoritative validator."""
+    return bool(errors) and all("expired" in error for error in errors)
+
+
+def _valid_prerequisites(value: object) -> tuple[list[dict[str, object]], list[str]]:
+    if not isinstance(value, list):
+        return [], ["selected_prerequisite_actions must be a list"]
+    actions, errors = [], []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            errors.append(f"selected_prerequisite_actions[{index}] must be an object")
+            continue
+        action = deepcopy(dict(item))
+        if not isinstance(action.get("action_id"), str) or not action["action_id"].strip():
+            errors.append(f"selected_prerequisite_actions[{index}].action_id must be non-empty")
+        capabilities = action.get("required_capabilities")
+        if not isinstance(capabilities, list) or not all(isinstance(cap, str) and cap.strip() for cap in capabilities):
+            errors.append(f"selected_prerequisite_actions[{index}].required_capabilities must be a string list")
+        evidence = action.get("evidence_path")
+        if evidence is not None and (not isinstance(evidence, str) or not evidence.strip()):
+            errors.append(f"selected_prerequisite_actions[{index}].evidence_path must be null or non-empty")
+        actions.append(action)
+    return actions, errors
+
+
+def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
+    """Resolve one already-selected local control bundle to a baton outcome."""
+    if not isinstance(control_bundle, Mapping):
+        return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT")
+    decision = control_bundle.get("decision")
+    if not isinstance(decision, Mapping):
+        return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT", errors=["decision must be an object"])
+    state = decision.get("control_state")
+    if state in TERMINAL_STATES:
+        return _out(str(state), "INPUT_CONTROL_STATE_PRESERVED")
+    if state != "ASSIGN":
+        return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT", errors=["control_state is invalid"])
+    for field in ("engine_id", "engine_status", "semantic_capability", "workflow_id"):
+        if not isinstance(decision.get(field), str) or not str(decision[field]).strip():
+            return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT", errors=[f"decision.{field} is required"])
+    if decision["engine_status"] != "available":
+        reason = "ENGINE_NOT_MATERIALIZED" if decision["engine_status"] == "not_materialized" else "ENGINE_UNAVAILABLE"
+        return _out("ESCALATE", reason, engine_id=decision["engine_id"])
+    if "additional_required_capabilities" in control_bundle or "final_required_capabilities" in control_bundle:
+        return _out("ESCALATE", "UNACCOUNTED_CAPABILITY_EXPANSION")
+
+    resolver, artifacts = _artifact_resolver(control_bundle.get("artifacts", []))
+    draft = control_bundle.get("assignment_compilation_draft")
+    semantics = control_bundle.get("assignment_draft_semantics")
+    if not isinstance(draft, Mapping) or not isinstance(semantics, Mapping):
+        return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT")
+    missing_semantics = [field for field in SEMANTIC_FIELDS if field not in semantics]
+    if missing_semantics:
+        return _out("ESCALATE", "MISSING_ASSIGNMENT_SEMANTICS", errors=missing_semantics)
+    envelope_ref = control_bundle.get("execution_envelope_ref")
+    compiled = compile_assignment(draft, envelope_ref, resolver, resolver) if isinstance(envelope_ref, str) else None
+    if compiled is None:
+        return _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT", errors=["execution_envelope_ref is required"])
+    if compiled.get("compilation_status") != "COMPILED":
+        return _out("ESCALATE", "COMPILE_REJECTED", compilation_errors=compiled.get("compilation_errors", []))
+    compiled_errors = validate_compiled_assignment(compiled, resolver, resolver)
+    if compiled_errors:
+        return _out("ESCALATE", "COMPILED_ASSIGNMENT_INVALID", errors=compiled_errors)
+
+    prerequisites, prerequisite_errors = _valid_prerequisites(control_bundle.get("selected_prerequisite_actions", []))
+    if prerequisite_errors:
+        return _out("ESCALATE", "MALFORMED_PREREQUISITE_ACTION", errors=prerequisite_errors)
+    compiled_actions = deepcopy(compiled["authorized_mandatory_actions"])
+    compiled_evidence = deepcopy(compiled["authorized_evidence_requirements"])
+    final_actions = compiled_actions + compiled_evidence + prerequisites
+    action_ids = [item.get("action_id") for item in final_actions if isinstance(item, Mapping)]
+    if len(action_ids) != len(set(action_ids)):
+        return _out("ESCALATE", "CONTRADICTORY_CONTROL_ARTIFACTS", errors=["duplicate final mandatory action id"])
+    required = sorted({cap.strip() for action in final_actions for cap in action.get("required_capabilities", [])})
+    paths = sorted({path for action in final_actions if isinstance((path := action.get("evidence_path")), str) and path.strip()})
+
+    profile_ref, route_ref = control_bundle.get("capability_profile_ref"), control_bundle.get("route_ref")
+    profile, route = artifacts.get(profile_ref), artifacts.get(route_ref)
+    if not isinstance(profile, Mapping) or not isinstance(route, Mapping):
+        return _out("ESCALATE", "REFERENCE_IDENTITY_MISMATCH")
+    profile_errors = validate_capability_profile(profile, resolver)
+    if profile_errors:
+        state = "WAIT" if _profile_is_only_stale(profile_errors) else "ESCALATE"
+        reason = "CAPABILITY_PROFILE_STALE" if state == "WAIT" else "MALFORMED_CAPABILITY_PROFILE"
+        return _out(state, reason, errors=profile_errors, capability_profile_ref=profile_ref)
+    route_profiles = {key: value for key, value in artifacts.items() if isinstance(value, Mapping) and value.get("artifact_type") == "CAPABILITY_PROFILE"}
+    route_errors = validate_execution_route(route, route_profiles, resolver)
+    if route_errors:
+        return _out("ESCALATE", "EXECUTION_ROUTE_INVALID", errors=route_errors)
+
+    subset = evaluate_assignment_admissibility(required, profile.get("available_capabilities", []))
+    admissibility = {
+        "artifact_type": "ASSIGNMENT_ADMISSIBILITY", "artifact_id": control_bundle.get("admissibility_id"),
+        "produced_by_role": "control-director", "assignment_id": None, "input_state_ref": draft.get("input_state_ref"),
+        "status": subset["status"], "provenance": [str(profile_ref)], "related_artifacts": [str(profile_ref), str(route_ref)],
+        "assignment_draft_id": draft.get("assignment_draft_ref"), "compiled_assignment_ref": compiled.get("artifact_id"),
+        "destination_id": profile.get("destination_id"), "runtime_identity": profile.get("runtime_identity"),
+        "capability_profile_ref": profile_ref, "route_ref": route_ref, "mandatory_actions": final_actions,
+        "required_capabilities": required, "available_capabilities": subset["available_capabilities"],
+        "unsatisfied_required_capabilities": subset["unsatisfied_required_capabilities"], "mandatory_evidence_paths": paths,
+        "execution_mode": decision.get("execution_mode"),
+    }
+    admission_errors = validate_admissibility_against_profile(admissibility, profile, resolver)
+    if admission_errors:
+        return _out("ESCALATE", "ASSIGNMENT_ADMISSIBILITY_INVALID", errors=admission_errors)
+    if subset["status"] != "ADMISSIBLE":
+        return _out("WAIT", "ASSIGNMENT_NOT_ADMISSIBLE", required_capabilities=required,
+                    available_capabilities=subset["available_capabilities"], missing_capabilities=subset["unsatisfied_required_capabilities"],
+                    destination_id=profile.get("destination_id"), capability_profile_ref=profile_ref)
+
+    assignment = deepcopy(dict(semantics))
+    assignment.update({
+        "artifact_type": "ASSIGNMENT", "artifact_id": control_bundle.get("assignment_id"), "produced_by_role": "control-director",
+        "assignment_id": control_bundle.get("assignment_id"), "input_state_ref": draft.get("input_state_ref"), "status": "ISSUED",
+        "provenance": [str(admissibility["artifact_id"])], "related_artifacts": [str(admissibility["artifact_id"]), str(profile_ref), str(route_ref)],
+        "execution_contract": {"assignment_draft_ref": draft.get("assignment_draft_ref"), "compiled_assignment_ref": compiled.get("artifact_id"),
+            "destination_id": profile.get("destination_id"), "runtime_identity": profile.get("runtime_identity"), "capability_profile_ref": profile_ref,
+            "admissibility_ref": admissibility.get("artifact_id"), "route_ref": route_ref, "proof_status": "PROVEN",
+            "required_capabilities": required, "unsatisfied_required_capabilities": [], "mandatory_evidence_paths": paths,
+            "execution_mode": decision.get("execution_mode")},
+    })
+    proof_errors = validate_assignment_execution_contract(assignment, admissibility, profile, resolver, route, route_profiles,
+                                                           compiled, resolver)
+    if proof_errors:
+        return _out("ESCALATE", "FINAL_ASSIGNMENT_PROOF_FAILED", errors=proof_errors)
+    return {"status": "SPAWN_READY", "control_state": "ASSIGN", "engine_id": decision["engine_id"],
+            "workflow_id": decision["workflow_id"], "compiled_assignment_ref": compiled["artifact_id"],
+            "capability_profile_ref": profile_ref, "route_ref": route_ref, "admissibility_ref": admissibility["artifact_id"],
+            "assignment_ref": assignment["artifact_id"], "compiled_assignment": compiled,
+            "assignment_admissibility": admissibility, "assignment": assignment}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Resolve one local structured control bundle to a pre-spawn outcome")
+    parser.add_argument("bundle", nargs="?", help="JSON bundle path; stdin when omitted")
+    args = parser.parse_args()
+    try:
+        with (open(args.bundle, encoding="utf-8") if args.bundle else sys.stdin) as source:
+            bundle = json.load(source)
+        result = resolve_spawn(bundle)
+    except (OSError, json.JSONDecodeError) as exc:
+        result = _out("ESCALATE", "MALFORMED_CONTROL_ARTIFACT", errors=[str(exc)])
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0 if result.get("control_state") in {"ASSIGN", "WAIT", "ESCALATE", "COMPLETE"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a thin, deterministic pre-spawn entrypoint that composes already-accepted compiler and executability surfaces into a locally-resolved pre-spawn decision path. 
- Preserve existing control baton semantics (`ASSIGN`, `WAIT`, `ESCALATE`, `COMPLETE`) and fail-closed behavior for malformed inputs, unavailable engines, stale profiles, missing capabilities, and proof-chain mismatches. 
- Expose a small importable function and a JSON CLI to enable deterministic unit/integration testing without introducing routing, registry, or network discovery logic.

### Description
- Added `tools/resolver_spawn.py` implementing `resolve_spawn(control_bundle)` and a CLI that reads one local JSON bundle and emits one structured JSON result. 
- Final mandatory actions are assembled as `COMPILED_ASSIGNMENT.authorized_mandatory_actions + COMPILED_ASSIGNMENT.authorized_evidence_requirements + supplied selected_prerequisite_actions`, and final required capabilities are derived as the union of those actions' `required_capabilities`. 
- The implementation reuses existing APIs: `compile_assignment` / `validate_compiled_assignment` and executability validators such as `evaluate_assignment_admissibility`, `validate_capability_profile`, `validate_execution_route`, and `validate_assignment_execution_contract` rather than reimplementing policy. 
- Added `tests/test_resolver_spawn.py` with representative positive cases for Software, already-admitted machine-only Research, and Verification, plus the required negative cases (compilation rejected, missing capability, stale/malformed profile, route/profile mismatch, unaccounted capability, non-materialized engine, missing semantics, duplicate actions) to validate the mapping rules and fail-closed behavior.

### Testing
- Ran the new integration test with `python -m unittest -v tests.test_resolver_spawn` and the 10 tests in that module passed. 
- Executed the repository regression and structural checks `python -m unittest discover -s tests -p 'test*.py'`, `python tools/research_policy.py --repo`, and `python tools/validate_structure.py`, and all applicable tests and checks succeeded (119 tests total across the suite passed). 
- Performed byte-compile checks with `python -m py_compile tools/resolver_spawn.py tools/assignment_compiler.py tools/executability.py` and validator runs, and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a987c59e26c8320a2352e3003c4642c)