### PR TITLE
Bind Research admission authority into resolve_spawn

### DIFF
--- a/tests/test_research_spawn_admission.py
+++ b/tests/test_research_spawn_admission.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import unittest
+
+from tests.test_research_machine_only import base_wp
+from tests.test_resolver_spawn import bundle
+from tools.research_policy import admit_work_package
+from tools.resolver_spawn import resolve_spawn
+
+POLICY_SURFACE = "tools.research_policy.admit_work_package"
+
+
+def attach_research_admission(value: dict, work_package: dict | None = None, admission_id: str = "RESEARCH-ADM-1") -> dict:
+    work = deepcopy(work_package or base_wp())
+    admission_result = admit_work_package(work)
+    admission = {
+        "artifact_type": "RESEARCH_ADMISSION",
+        "artifact_id": admission_id,
+        "produced_by_role": "research-engine",
+        "status": admission_result["ADMISSION_STATUS"],
+        "provenance": [POLICY_SURFACE, work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
+        "related_artifacts": [work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
+        "policy_surface": POLICY_SURFACE,
+        "work_package_id": work["WORK_PACKAGE_ID"],
+        "question_id": work["QUESTION_ID"],
+        "work_package": work,
+        "admission_result": admission_result,
+    }
+    value["decision"].update({
+        "research_admission_ref": admission_id,
+        "research_work_package_id": work["WORK_PACKAGE_ID"],
+        "research_question_id": work["QUESTION_ID"],
+    })
+    value["artifacts"].append(admission)
+    return admission
+
+
+def research_bundle() -> dict:
+    return bundle("research", "execute_research_work", "machine-only-execution")
+
+
+class ResearchSpawnAdmissionContinuityTest(unittest.TestCase):
+    def assert_escalates(self, value: dict, reason: str) -> dict:
+        result = resolve_spawn(value)
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", reason), result)
+        self.assertNotIn("assignment", result)
+        return result
+
+    def test_positive_real_research_admission_composes_to_spawn_ready(self) -> None:
+        value = research_bundle()
+        admission = attach_research_admission(value)
+        self.assertEqual(admission["admission_result"]["ADMISSION_STATUS"], "ADMITTED_MACHINE_RESEARCH")
+        self.assertNotIn("research_admission", value["decision"])
+
+        result = resolve_spawn(value)
+
+        self.assertEqual((result["control_state"], result["status"]), ("ASSIGN", "SPAWN_READY"), result)
+        self.assertEqual(result["research_admission_ref"], admission["artifact_id"])
+        self.assertEqual(result["research_admission"]["work_package_id"], admission["work_package_id"])
+        self.assertEqual(result["research_admission"]["question_id"], admission["question_id"])
+        self.assertEqual(result["assignment_admissibility"]["status"], "ADMISSIBLE")
+        self.assertEqual(result["assignment"]["execution_contract"]["proof_status"], "PROVEN")
+        self.assertIn(admission["artifact_id"], result["assignment"]["related_artifacts"])
+
+    def test_A_no_research_admission_fails_closed(self) -> None:
+        self.assert_escalates(research_bundle(), "RESEARCH_ADMISSION_REQUIRED")
+
+    def test_B_bare_legacy_marker_is_not_authority(self) -> None:
+        value = research_bundle()
+        value["decision"]["research_admission"] = "MACHINE_ONLY_ADMITTED"
+        self.assert_escalates(value, "RESEARCH_ADMISSION_REQUIRED")
+
+    def test_C_unresolved_admission_ref_fails_closed(self) -> None:
+        value = research_bundle()
+        attach_research_admission(value)
+        value["decision"]["research_admission_ref"] = "RESEARCH-ADM-MISSING"
+        self.assert_escalates(value, "RESEARCH_ADMISSION_UNRESOLVED")
+
+    def test_D_malformed_admission_result_fails_closed(self) -> None:
+        value = research_bundle()
+        admission = attach_research_admission(value)
+        admission["admission_result"] = "ADMITTED_MACHINE_RESEARCH"
+        self.assert_escalates(value, "MALFORMED_RESEARCH_ADMISSION")
+
+    def test_E_non_admitted_work_package_fails_closed(self) -> None:
+        value = research_bundle()
+        work = base_wp()
+        work["REQUIRES_THIRD_PARTY_HUMAN"] = True
+        admission = attach_research_admission(value, work)
+        self.assertNotEqual(admission["admission_result"]["ADMISSION_STATUS"], "ADMITTED_MACHINE_RESEARCH")
+        self.assert_escalates(value, "RESEARCH_ADMISSION_NOT_ADMITTED")
+
+    def test_F_admission_for_other_work_package_cannot_authorize_selected_work(self) -> None:
+        value = research_bundle()
+        attach_research_admission(value)
+        value["decision"]["research_work_package_id"] = "WP-OTHER"
+        self.assert_escalates(value, "RESEARCH_ADMISSION_IDENTITY_MISMATCH")
+
+    def test_G_question_identity_mismatch_fails_closed(self) -> None:
+        value = research_bundle()
+        attach_research_admission(value)
+        value["decision"]["research_question_id"] = "Q-OTHER"
+        self.assert_escalates(value, "RESEARCH_ADMISSION_IDENTITY_MISMATCH")
+
+    def test_H_lookalike_without_research_provenance_fails_closed(self) -> None:
+        value = research_bundle()
+        admission = attach_research_admission(value)
+        admission["provenance"] = [admission["work_package_id"], admission["question_id"]]
+        self.assert_escalates(value, "MALFORMED_RESEARCH_ADMISSION")
+
+    def test_I_valid_research_admission_does_not_bypass_generic_executability(self) -> None:
+        value = research_bundle()
+        attach_research_admission(value)
+        value["assignment_compilation_draft"]["mandatory_actions"][0]["required_capabilities"].append("database_access")
+        value["assignment_compilation_draft"]["authorized_required_capabilities"].append("database_access")
+
+        result = resolve_spawn(value)
+
+        self.assertEqual((result["control_state"], result["reason"]), ("WAIT", "ASSIGNMENT_NOT_ADMISSIBLE"), result)
+        self.assertEqual(result["missing_capabilities"], ["database_access"])
+        self.assertNotIn("assignment", result)
+
+    def test_software_and_verification_do_not_require_research_fields(self) -> None:
+        software = resolve_spawn(bundle())
+        verification_value = bundle("verification", "verify_completion_claim", "exact-evidence-verification")
+        verification_value["assignment_compilation_draft"]["evidence_requirements"] = [
+            {
+                "action_id": "verification-evidence",
+                "claim_ref": "claim-1",
+                "responsibility": "EXECUTOR",
+                "required_capabilities": ["python_runtime"],
+                "evidence_path": None,
+                "obligation_class": "local_evidence",
+            }
+        ]
+        verification = resolve_spawn(verification_value)
+        self.assertEqual((software["control_state"], software["status"]), ("ASSIGN", "SPAWN_READY"), software)
+        self.assertEqual((verification["control_state"], verification["status"]), ("ASSIGN", "SPAWN_READY"), verification)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_research_spawn_admission.py
+++ b/tests/test_research_spawn_admission.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 import unittest
 
+from tests.test_assignment_compiler import action
 from tests.test_research_machine_only import base_wp
 from tests.test_resolver_spawn import bundle
 from tools.research_policy import admit_work_package
@@ -125,14 +126,7 @@ class ResearchSpawnAdmissionContinuityTest(unittest.TestCase):
         software = resolve_spawn(bundle())
         verification_value = bundle("verification", "verify_completion_claim", "exact-evidence-verification")
         verification_value["assignment_compilation_draft"]["evidence_requirements"] = [
-            {
-                "action_id": "verification-evidence",
-                "claim_ref": "claim-1",
-                "responsibility": "EXECUTOR",
-                "required_capabilities": ["python_runtime"],
-                "evidence_path": None,
-                "obligation_class": "local_evidence",
-            }
+            action("verification-evidence", capabilities=["python_runtime"], obligation_class="local_evidence")
         ]
         verification = resolve_spawn(verification_value)
         self.assertEqual((software["control_state"], software["status"]), ("ASSIGN", "SPAWN_READY"), software)

--- a/tests/test_research_spawn_admission.py
+++ b/tests/test_research_spawn_admission.py
@@ -16,17 +16,13 @@ def attach_research_admission(value: dict, work_package: dict | None = None, adm
     work = deepcopy(work_package or base_wp())
     admission_result = admit_work_package(work)
     admission = {
-        "artifact_type": "RESEARCH_ADMISSION",
         "artifact_id": admission_id,
-        "produced_by_role": "research-engine",
-        "status": admission_result["ADMISSION_STATUS"],
-        "provenance": [POLICY_SURFACE, work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
-        "related_artifacts": [work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
-        "policy_surface": POLICY_SURFACE,
-        "work_package_id": work["WORK_PACKAGE_ID"],
-        "question_id": work["QUESTION_ID"],
-        "work_package": work,
-        "admission_result": admission_result,
+        **admission_result,
+        "WORK_PACKAGE_ID": work["WORK_PACKAGE_ID"],
+        "QUESTION_ID": work["QUESTION_ID"],
+        "POLICY_SURFACE": POLICY_SURFACE,
+        "PROVENANCE": [POLICY_SURFACE, work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
+        "WORK_PACKAGE": work,
     }
     value["decision"].update({
         "research_admission_ref": admission_id,
@@ -51,15 +47,15 @@ class ResearchSpawnAdmissionContinuityTest(unittest.TestCase):
     def test_positive_real_research_admission_composes_to_spawn_ready(self) -> None:
         value = research_bundle()
         admission = attach_research_admission(value)
-        self.assertEqual(admission["admission_result"]["ADMISSION_STATUS"], "ADMITTED_MACHINE_RESEARCH")
+        self.assertEqual(admission["ADMISSION_STATUS"], "ADMITTED_MACHINE_RESEARCH")
         self.assertNotIn("research_admission", value["decision"])
 
         result = resolve_spawn(value)
 
         self.assertEqual((result["control_state"], result["status"]), ("ASSIGN", "SPAWN_READY"), result)
         self.assertEqual(result["research_admission_ref"], admission["artifact_id"])
-        self.assertEqual(result["research_admission"]["work_package_id"], admission["work_package_id"])
-        self.assertEqual(result["research_admission"]["question_id"], admission["question_id"])
+        self.assertEqual(result["research_admission"]["WORK_PACKAGE_ID"], admission["WORK_PACKAGE_ID"])
+        self.assertEqual(result["research_admission"]["QUESTION_ID"], admission["QUESTION_ID"])
         self.assertEqual(result["assignment_admissibility"]["status"], "ADMISSIBLE")
         self.assertEqual(result["assignment"]["execution_contract"]["proof_status"], "PROVEN")
         self.assertIn(admission["artifact_id"], result["assignment"]["related_artifacts"])
@@ -81,15 +77,15 @@ class ResearchSpawnAdmissionContinuityTest(unittest.TestCase):
     def test_D_malformed_admission_result_fails_closed(self) -> None:
         value = research_bundle()
         admission = attach_research_admission(value)
-        admission["admission_result"] = "ADMITTED_MACHINE_RESEARCH"
-        self.assert_escalates(value, "MALFORMED_RESEARCH_ADMISSION")
+        admission["ERRORS"] = "not-a-list"
+        self.assert_escalates(value, "RESEARCH_ADMISSION_RESULT_MISMATCH")
 
     def test_E_non_admitted_work_package_fails_closed(self) -> None:
         value = research_bundle()
         work = base_wp()
         work["REQUIRES_THIRD_PARTY_HUMAN"] = True
         admission = attach_research_admission(value, work)
-        self.assertNotEqual(admission["admission_result"]["ADMISSION_STATUS"], "ADMITTED_MACHINE_RESEARCH")
+        self.assertNotEqual(admission["ADMISSION_STATUS"], "ADMITTED_MACHINE_RESEARCH")
         self.assert_escalates(value, "RESEARCH_ADMISSION_NOT_ADMITTED")
 
     def test_F_admission_for_other_work_package_cannot_authorize_selected_work(self) -> None:
@@ -107,7 +103,7 @@ class ResearchSpawnAdmissionContinuityTest(unittest.TestCase):
     def test_H_lookalike_without_research_provenance_fails_closed(self) -> None:
         value = research_bundle()
         admission = attach_research_admission(value)
-        admission["provenance"] = [admission["work_package_id"], admission["question_id"]]
+        admission["PROVENANCE"] = [admission["WORK_PACKAGE_ID"], admission["QUESTION_ID"]]
         self.assert_escalates(value, "MALFORMED_RESEARCH_ADMISSION")
 
     def test_I_valid_research_admission_does_not_bypass_generic_executability(self) -> None:

--- a/tests/test_resolver_spawn.py
+++ b/tests/test_resolver_spawn.py
@@ -11,10 +11,13 @@ from unittest.mock import patch
 
 from tests.test_assignment_compiler import action, claim, draft, envelope
 from tests.test_executability import governed_chain, valid_chain
+from tests.test_research_machine_only import base_wp
 import tools.resolver_spawn as resolver_spawn
+from tools.research_policy import admit_work_package
 from tools.resolver_spawn import resolve_spawn
 
 ROOT = Path(__file__).resolve().parents[1]
+RESEARCH_POLICY_SURFACE = "tools.research_policy.admit_work_package"
 
 
 def bundle(engine="production/software", capability="implement_software_change", workflow="implementation"):
@@ -44,6 +47,24 @@ def bundle(engine="production/software", capability="implement_software_change",
     }
 
 
+def attach_research_admission(value, work_package=None, admission_id="RESEARCH-ADM-1"):
+    work = deepcopy(work_package or base_wp())
+    admission_result = admit_work_package(work)
+    admission = {
+        "artifact_type": "RESEARCH_ADMISSION", "artifact_id": admission_id, "produced_by_role": "research-engine",
+        "status": admission_result["ADMISSION_STATUS"],
+        "provenance": [RESEARCH_POLICY_SURFACE, work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
+        "related_artifacts": [work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
+        "policy_surface": RESEARCH_POLICY_SURFACE, "work_package_id": work["WORK_PACKAGE_ID"],
+        "question_id": work["QUESTION_ID"], "work_package": work, "admission_result": admission_result,
+    }
+    value["decision"].update({"research_admission_ref": admission_id,
+                              "research_work_package_id": work["WORK_PACKAGE_ID"],
+                              "research_question_id": work["QUESTION_ID"]})
+    value["artifacts"].append(admission)
+    return admission
+
+
 class ResolverSpawnTest(unittest.TestCase):
     def assert_spawn_ready(self, value):
         result = resolve_spawn(value)
@@ -57,7 +78,7 @@ class ResolverSpawnTest(unittest.TestCase):
             bundle("research", "execute_research_work", "machine-only-execution"),
             bundle("verification", "verify_completion_claim", "exact-evidence-verification"),
         ]
-        cases[1]["decision"]["research_admission"] = "MACHINE_ONLY_ADMITTED"
+        attach_research_admission(cases[1])
         cases[2]["assignment_compilation_draft"]["evidence_requirements"] = [
             action("verification-evidence", capabilities=["python_runtime"], obligation_class="local_evidence")]
         for value in cases:
@@ -136,7 +157,7 @@ class ResolverSpawnTest(unittest.TestCase):
     def test_missing_semantics_fail_closed(self):
         value = bundle(); del value["assignment_draft_semantics"]["objective"]
         result = resolve_spawn(value)
-        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "MISSING_ASSIGNMENT_SEMANTICS"))
+        self.assertEqual((result["control_state"], result["reason"]), ("ESCALATE", "MISSING_ASSIGNMENT_SEMANTICS"), result)
 
     def test_duplicate_action_identity_fails_closed(self):
         value = bundle(); value["selected_prerequisite_actions"] = [{"action_id": "test", "required_capabilities": ["shell"], "evidence_path": None}]

--- a/tests/test_resolver_spawn.py
+++ b/tests/test_resolver_spawn.py
@@ -51,12 +51,13 @@ def attach_research_admission(value, work_package=None, admission_id="RESEARCH-A
     work = deepcopy(work_package or base_wp())
     admission_result = admit_work_package(work)
     admission = {
-        "artifact_type": "RESEARCH_ADMISSION", "artifact_id": admission_id, "produced_by_role": "research-engine",
-        "status": admission_result["ADMISSION_STATUS"],
-        "provenance": [RESEARCH_POLICY_SURFACE, work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
-        "related_artifacts": [work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
-        "policy_surface": RESEARCH_POLICY_SURFACE, "work_package_id": work["WORK_PACKAGE_ID"],
-        "question_id": work["QUESTION_ID"], "work_package": work, "admission_result": admission_result,
+        "artifact_id": admission_id,
+        **admission_result,
+        "WORK_PACKAGE_ID": work["WORK_PACKAGE_ID"],
+        "QUESTION_ID": work["QUESTION_ID"],
+        "POLICY_SURFACE": RESEARCH_POLICY_SURFACE,
+        "PROVENANCE": [RESEARCH_POLICY_SURFACE, work["WORK_PACKAGE_ID"], work["QUESTION_ID"]],
+        "WORK_PACKAGE": work,
     }
     value["decision"].update({"research_admission_ref": admission_id,
                               "research_work_package_id": work["WORK_PACKAGE_ID"],

--- a/tools/resolver_spawn.py
+++ b/tools/resolver_spawn.py
@@ -21,9 +21,15 @@ from tools.executability import (
     validate_execution_route,
     validate_state_observation,
 )
+from tools.research_policy import admit_work_package
 
 TERMINAL_STATES = {"WAIT", "ESCALATE", "COMPLETE"}
 SEMANTIC_FIELDS = ("objective", "authority", "scope", "acceptance", "stop_conditions", "result_to")
+RESEARCH_POLICY_SURFACE = "tools.research_policy.admit_work_package"
+RESEARCH_ADMISSION_FIELDS = {
+    "artifact_type", "artifact_id", "produced_by_role", "status", "provenance", "related_artifacts",
+    "policy_surface", "work_package_id", "question_id", "work_package", "admission_result",
+}
 
 
 def _out(control_state: str, reason: str, **details: object) -> dict[str, object]:
@@ -76,6 +82,56 @@ def _valid_prerequisites(value: object) -> tuple[list[dict[str, object]], list[s
     return actions, errors
 
 
+def _research_admission(
+    decision: Mapping[str, object],
+    artifacts: Mapping[str, Mapping[str, object]],
+) -> tuple[Mapping[str, object] | None, dict[str, object] | None]:
+    """Validate Research-owned admission continuity without owning Research policy."""
+    admission_ref = decision.get("research_admission_ref")
+    if not isinstance(admission_ref, str) or not admission_ref.strip():
+        return None, _out("ESCALATE", "RESEARCH_ADMISSION_REQUIRED", engine_id="research")
+    selected_work_id = decision.get("research_work_package_id")
+    selected_question_id = decision.get("research_question_id")
+    if not isinstance(selected_work_id, str) or not selected_work_id.strip() or not isinstance(selected_question_id, str) or not selected_question_id.strip():
+        return None, _out("ESCALATE", "RESEARCH_WORK_IDENTITY_REQUIRED", engine_id="research")
+
+    admission = artifacts.get(admission_ref)
+    if not isinstance(admission, Mapping):
+        return None, _out("ESCALATE", "RESEARCH_ADMISSION_UNRESOLVED", engine_id="research", research_admission_ref=admission_ref)
+    if set(admission) != RESEARCH_ADMISSION_FIELDS:
+        return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
+    if admission.get("artifact_type") != "RESEARCH_ADMISSION" or admission.get("artifact_id") != admission_ref:
+        return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
+    if admission.get("produced_by_role") != "research-engine" or admission.get("policy_surface") != RESEARCH_POLICY_SURFACE:
+        return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
+
+    work_package = admission.get("work_package")
+    admission_result = admission.get("admission_result")
+    if not isinstance(work_package, Mapping) or not isinstance(admission_result, Mapping):
+        return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
+    work_id = work_package.get("WORK_PACKAGE_ID")
+    question_id = work_package.get("QUESTION_ID")
+    if not isinstance(work_id, str) or not work_id.strip() or not isinstance(question_id, str) or not question_id.strip():
+        return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
+    if admission.get("work_package_id") != work_id or admission.get("question_id") != question_id:
+        return None, _out("ESCALATE", "RESEARCH_ADMISSION_IDENTITY_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
+    if selected_work_id != work_id or selected_question_id != question_id:
+        return None, _out("ESCALATE", "RESEARCH_ADMISSION_IDENTITY_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
+
+    expected_provenance = [RESEARCH_POLICY_SURFACE, work_id, question_id]
+    if admission.get("provenance") != expected_provenance or admission.get("related_artifacts") != [work_id, question_id]:
+        return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
+
+    authoritative_result = admit_work_package(dict(work_package))
+    if dict(admission_result) != authoritative_result:
+        return None, _out("ESCALATE", "RESEARCH_ADMISSION_RESULT_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
+    if admission.get("status") != authoritative_result.get("ADMISSION_STATUS"):
+        return None, _out("ESCALATE", "RESEARCH_ADMISSION_RESULT_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
+    if authoritative_result.get("ADMISSION_STATUS") != "ADMITTED_MACHINE_RESEARCH":
+        return None, _out("ESCALATE", "RESEARCH_ADMISSION_NOT_ADMITTED", engine_id="research", research_admission_ref=admission_ref)
+    return admission, None
+
+
 def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     """Resolve one already-selected local control bundle to a baton outcome."""
     if not isinstance(control_bundle, Mapping):
@@ -94,8 +150,6 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     if decision["engine_status"] != "available":
         reason = "ENGINE_NOT_MATERIALIZED" if decision["engine_status"] == "not_materialized" else "ENGINE_UNAVAILABLE"
         return _out("ESCALATE", reason, engine_id=decision["engine_id"])
-    if decision["engine_id"] == "research" and decision.get("research_admission") != "MACHINE_ONLY_ADMITTED":
-        return _out("ESCALATE", "RESEARCH_ADMISSION_REQUIRED", engine_id=decision["engine_id"])
     if "additional_required_capabilities" in control_bundle or "final_required_capabilities" in control_bundle:
         return _out("ESCALATE", "UNACCOUNTED_CAPABILITY_EXPANSION")
 
@@ -103,6 +157,12 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     if artifact_errors:
         reason = "CONTRADICTORY_CONTROL_ARTIFACTS" if any(error.startswith("duplicate artifact_id:") for error in artifact_errors) else "MALFORMED_CONTROL_ARTIFACT"
         return _out("ESCALATE", reason, errors=artifact_errors)
+    research_admission = None
+    if decision["engine_id"] == "research":
+        research_admission, research_error = _research_admission(decision, artifacts)
+        if research_error is not None:
+            return research_error
+
     state_observation_ref = control_bundle.get("input_state_observation_ref")
     state_observation = artifacts.get(state_observation_ref) if isinstance(state_observation_ref, str) else None
     if not isinstance(state_observation, Mapping):
@@ -173,10 +233,11 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
         return _out("ESCALATE", "EXECUTION_ROUTE_INVALID", errors=route_errors)
 
     subset = evaluate_assignment_admissibility(required, profile.get("available_capabilities", []))
+    research_refs = [str(research_admission["artifact_id"])] if isinstance(research_admission, Mapping) else []
     admissibility = {
         "artifact_type": "ASSIGNMENT_ADMISSIBILITY", "artifact_id": control_bundle.get("admissibility_id"),
         "produced_by_role": "control-director", "assignment_id": control_bundle.get("assignment_id"), "input_state_ref": draft.get("input_state_ref"),
-        "status": subset["status"], "provenance": [str(profile_ref)], "related_artifacts": [str(profile_ref), str(route_ref)],
+        "status": subset["status"], "provenance": [str(profile_ref)], "related_artifacts": [str(profile_ref), str(route_ref), *research_refs],
         "assignment_draft_id": draft.get("assignment_draft_ref"), "compiled_assignment_ref": compiled.get("artifact_id"),
         "destination_id": profile.get("destination_id"), "runtime_identity": profile.get("runtime_identity"),
         "capability_profile_ref": profile_ref, "route_ref": route_ref, "mandatory_actions": final_actions,
@@ -201,7 +262,7 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
     assignment.update({
         "artifact_type": "ASSIGNMENT", "artifact_id": control_bundle.get("assignment_id"), "produced_by_role": "control-director",
         "assignment_id": control_bundle.get("assignment_id"), "input_state_ref": draft.get("input_state_ref"), "status": "ISSUED",
-        "provenance": [str(admissibility["artifact_id"])], "related_artifacts": [str(admissibility["artifact_id"]), str(profile_ref), str(route_ref)],
+        "provenance": [str(admissibility["artifact_id"])], "related_artifacts": [str(admissibility["artifact_id"]), str(profile_ref), str(route_ref), *research_refs],
         "execution_contract": {"assignment_draft_ref": draft.get("assignment_draft_ref"), "compiled_assignment_ref": compiled.get("artifact_id"),
             "destination_id": profile.get("destination_id"), "runtime_identity": profile.get("runtime_identity"), "capability_profile_ref": profile_ref,
             "admissibility_ref": admissibility.get("artifact_id"), "route_ref": route_ref, "proof_status": "PROVEN",
@@ -212,13 +273,17 @@ def resolve_spawn(control_bundle: Mapping[str, object]) -> dict[str, object]:
                                                            compiled, resolver)
     if proof_errors:
         return _out("ESCALATE", "FINAL_ASSIGNMENT_PROOF_FAILED", errors=proof_errors)
-    return {"status": "SPAWN_READY", "control_state": "ASSIGN", "engine_id": decision["engine_id"],
-            "workflow_id": decision["workflow_id"], "compiled_assignment_ref": compiled["artifact_id"],
-            "capability_profile_ref": profile_ref, "route_ref": route_ref, "admissibility_ref": admissibility["artifact_id"],
-            "assignment_ref": assignment["artifact_id"], "compiled_assignment": compiled,
-            "assignment_admissibility": admissibility, "assignment": assignment,
-            "capability_profile": profile, "execution_route": route,
-            "input_state_observation": state_observation}
+    result = {"status": "SPAWN_READY", "control_state": "ASSIGN", "engine_id": decision["engine_id"],
+              "workflow_id": decision["workflow_id"], "compiled_assignment_ref": compiled["artifact_id"],
+              "capability_profile_ref": profile_ref, "route_ref": route_ref, "admissibility_ref": admissibility["artifact_id"],
+              "assignment_ref": assignment["artifact_id"], "compiled_assignment": compiled,
+              "assignment_admissibility": admissibility, "assignment": assignment,
+              "capability_profile": profile, "execution_route": route,
+              "input_state_observation": state_observation}
+    if isinstance(research_admission, Mapping):
+        result["research_admission_ref"] = research_admission["artifact_id"]
+        result["research_admission"] = research_admission
+    return result
 
 
 def main() -> int:

--- a/tools/resolver_spawn.py
+++ b/tools/resolver_spawn.py
@@ -26,9 +26,9 @@ from tools.research_policy import admit_work_package
 TERMINAL_STATES = {"WAIT", "ESCALATE", "COMPLETE"}
 SEMANTIC_FIELDS = ("objective", "authority", "scope", "acceptance", "stop_conditions", "result_to")
 RESEARCH_POLICY_SURFACE = "tools.research_policy.admit_work_package"
+RESEARCH_RESULT_FIELDS = {"ADMISSION_STATUS", "ERROR_CODE", "REQUIRE_MACHINE_REDESIGN", "ERRORS"}
 RESEARCH_ADMISSION_FIELDS = {
-    "artifact_type", "artifact_id", "produced_by_role", "status", "provenance", "related_artifacts",
-    "policy_surface", "work_package_id", "question_id", "work_package", "admission_result",
+    "artifact_id", *RESEARCH_RESULT_FIELDS, "WORK_PACKAGE_ID", "QUESTION_ID", "POLICY_SURFACE", "PROVENANCE", "WORK_PACKAGE",
 }
 
 
@@ -86,7 +86,7 @@ def _research_admission(
     decision: Mapping[str, object],
     artifacts: Mapping[str, Mapping[str, object]],
 ) -> tuple[Mapping[str, object] | None, dict[str, object] | None]:
-    """Validate Research-owned admission continuity without owning Research policy."""
+    """Revalidate exact Research work through the existing Research policy surface."""
     admission_ref = decision.get("research_admission_ref")
     if not isinstance(admission_ref, str) or not admission_ref.strip():
         return None, _out("ESCALATE", "RESEARCH_ADMISSION_REQUIRED", engine_id="research")
@@ -100,32 +100,26 @@ def _research_admission(
         return None, _out("ESCALATE", "RESEARCH_ADMISSION_UNRESOLVED", engine_id="research", research_admission_ref=admission_ref)
     if set(admission) != RESEARCH_ADMISSION_FIELDS:
         return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
-    if admission.get("artifact_type") != "RESEARCH_ADMISSION" or admission.get("artifact_id") != admission_ref:
-        return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
-    if admission.get("produced_by_role") != "research-engine" or admission.get("policy_surface") != RESEARCH_POLICY_SURFACE:
+    if admission.get("artifact_id") != admission_ref or admission.get("POLICY_SURFACE") != RESEARCH_POLICY_SURFACE:
         return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
 
-    work_package = admission.get("work_package")
-    admission_result = admission.get("admission_result")
-    if not isinstance(work_package, Mapping) or not isinstance(admission_result, Mapping):
+    work_package = admission.get("WORK_PACKAGE")
+    if not isinstance(work_package, Mapping):
         return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
     work_id = work_package.get("WORK_PACKAGE_ID")
     question_id = work_package.get("QUESTION_ID")
     if not isinstance(work_id, str) or not work_id.strip() or not isinstance(question_id, str) or not question_id.strip():
         return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
-    if admission.get("work_package_id") != work_id or admission.get("question_id") != question_id:
+    if admission.get("WORK_PACKAGE_ID") != work_id or admission.get("QUESTION_ID") != question_id:
         return None, _out("ESCALATE", "RESEARCH_ADMISSION_IDENTITY_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
     if selected_work_id != work_id or selected_question_id != question_id:
         return None, _out("ESCALATE", "RESEARCH_ADMISSION_IDENTITY_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
-
-    expected_provenance = [RESEARCH_POLICY_SURFACE, work_id, question_id]
-    if admission.get("provenance") != expected_provenance or admission.get("related_artifacts") != [work_id, question_id]:
+    if admission.get("PROVENANCE") != [RESEARCH_POLICY_SURFACE, work_id, question_id]:
         return None, _out("ESCALATE", "MALFORMED_RESEARCH_ADMISSION", engine_id="research", research_admission_ref=admission_ref)
 
     authoritative_result = admit_work_package(dict(work_package))
-    if dict(admission_result) != authoritative_result:
-        return None, _out("ESCALATE", "RESEARCH_ADMISSION_RESULT_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
-    if admission.get("status") != authoritative_result.get("ADMISSION_STATUS"):
+    carried_result = {field: admission.get(field) for field in RESEARCH_RESULT_FIELDS}
+    if carried_result != authoritative_result:
         return None, _out("ESCALATE", "RESEARCH_ADMISSION_RESULT_MISMATCH", engine_id="research", research_admission_ref=admission_ref)
     if authoritative_result.get("ADMISSION_STATUS") != "ADMITTED_MACHINE_RESEARCH":
         return None, _out("ESCALATE", "RESEARCH_ADMISSION_NOT_ADMITTED", engine_id="research", research_admission_ref=admission_ref)


### PR DESCRIPTION
P2-R2 implementation candidate for P2-GATE-02 only.

Production change is bounded to `tools/resolver_spawn.py`; focused tests are in `tests/test_research_spawn_admission.py` and `tests/test_resolver_spawn.py`.

The candidate removes caller-controlled `MACHINE_ONLY_ADMITTED` from the Research authority path and binds Research spawning to the existing `tools.research_policy.admit_work_package()` surface, exact `WORK_PACKAGE_ID` / `QUESTION_ID`, and `ADMITTED_MACHINE_RESEARCH`, while preserving the generic capability/route/admissibility chain.

Implementation/static review completed, but bounded Python execution was unavailable in the implementation session. This PR is therefore created as a DRAFT verification candidate. Do not merge until independent exact-candidate execution verification passes.

Frozen candidate HEAD for verification: `371bc7a3496c9711f88f94e7e40a414cde200e73`.
Base: `be82cfdc1773ce17d9217098b5b2f18abc48dd17`.