### PR TITLE
55-A: separate semantic assignment contract from execution hints

### DIFF
--- a/contracts/ASSIGNMENT_COMPILATION_CONTRACT.md
+++ b/contracts/ASSIGNMENT_COMPILATION_CONTRACT.md
@@ -58,6 +58,33 @@ authority. Execution-envelope support likewise resolves through an exact local
 `EXECUTION_ENVELOPE` artifact. The compiled artifact retains that envelope ref;
 a caller-supplied capability or obligation set cannot broaden it.
 
+## Semantic contract and execution hints
+
+The frozen semantic contract and environment-local execution mechanics are
+separate surfaces. `COMPILED_ASSIGNMENT.execution_hints` may carry bounded,
+structured executor-local guidance such as a known command, path, wrapper,
+discovery suggestion, or implementation note. Hints are structurally validated
+and preserved, but their contents are not interpreted as authority or semantic
+obligations.
+
+Execution hints contribute zero authority, mandatory actions, evidence
+requirements, required capabilities, acceptance requirements, invariants, or
+semantic stop conditions. In particular, a hint that names a capability or says
+"stop" does not enter capability closure or STOP ownership. Failure or absence
+of a hinted mechanism is therefore not itself compilation failure when the
+semantic contract remains satisfiable by another supported mechanism.
+
+This distinction does not weaken exact mechanics that are already represented
+as real mandatory actions, evidence requirements, invariants, authority gates,
+or acceptance requirements. Those remain inside the existing compilation and
+admissibility closure.
+
+The current resolver spawn result exposes the exact `compiled_assignment`
+alongside the executable `assignment`, so #55-A does not duplicate hints into
+the final `ASSIGNMENT` artifact. The Executor can receive the preserved hints
+from the compiled artifact without expanding the final assignment schema or
+creating a second obligation system.
+
 ## Binding chain
 
 `ASSIGNMENT_ADMISSIBILITY` and executable `ASSIGNMENT` both cite the exact

--- a/schemas/compiled-assignment.schema.json
+++ b/schemas/compiled-assignment.schema.json
@@ -11,6 +11,38 @@
         "minLength": 1
       }
     },
+    "executionHint": {
+      "type": "object",
+      "description": "Non-authoritative executor-local guidance. An execution hint creates no authority, mandatory action, evidence requirement, required capability, acceptance requirement, invariant, or semantic stop condition.",
+      "required": [
+        "hint_id",
+        "hint_kind",
+        "description"
+      ],
+      "properties": {
+        "hint_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hint_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "obligation": {
       "type": "object",
       "required": [
@@ -366,6 +398,13 @@
         "additionalProperties": false
       }
     },
+    "execution_hints": {
+      "type": "array",
+      "description": "Non-authoritative executor-local guidance preserved for adaptation only. This field contributes zero authority, obligations, required capabilities, acceptance requirements, invariants, or semantic stop conditions.",
+      "items": {
+        "$ref": "#/$defs/executionHint"
+      }
+    },
     "supported_execution_envelope_status": {
       "enum": [
         "SUPPORTED",
@@ -404,7 +443,8 @@
               "RESPONSIBILITY_MISMATCH",
               "UNSUPPORTED_EXECUTION_ENVELOPE",
               "INVALID_CONTEXT_AUTHORITY",
-              "COMPILED_CAPABILITY_MISMATCH"
+              "COMPILED_CAPABILITY_MISMATCH",
+              "INVALID_EXECUTION_HINT"
             ]
           },
           "detail": {

--- a/tests/test_assignment_compiler.py
+++ b/tests/test_assignment_compiler.py
@@ -4,9 +4,10 @@ import unittest
 
 from tools.assignment_compiler import (
     AUTHORITY_CLASSES, CONTEXT_AUTHORITIES, COMPILED_CAPABILITY_MISMATCH,
-    INVALID_FROZEN_IDENTITY_FOR_MOVING_TARGET, OBLIGATION_NOT_AUTHORIZED,
-    PLATFORM_FACT_REAUTHENTICATION, UNSUPPORTED_EXECUTION_ENVELOPE,
-    compile_assignment, validate_compiled_assignment,
+    INVALID_EXECUTION_HINT, INVALID_FROZEN_IDENTITY_FOR_MOVING_TARGET,
+    OBLIGATION_NOT_AUTHORIZED, PLATFORM_FACT_REAUTHENTICATION,
+    UNSUPPORTED_EXECUTION_ENVELOPE, compile_assignment,
+    validate_compiled_assignment,
 )
 from tools.executability import evaluate_assignment_admissibility
 
@@ -122,6 +123,64 @@ class AssignmentCompilerTest(unittest.TestCase):
 
     def test_supported_compile_can_still_fail_destination(self):
         result=compile_ok(draft()); self.assertEqual(result["status"],"COMPILED"); self.assertEqual(evaluate_assignment_admissibility(result["authorized_required_capabilities"],[])["status"],"NOT_ADMISSIBLE")
+
+    def test_assignment_without_hints_preserves_semantic_behavior(self):
+        result = compile_ok(draft())
+        self.assertEqual(result["status"], "COMPILED")
+        self.assertEqual(result["execution_hints"], [])
+        self.assertEqual(result["authorized_required_capabilities"], ["shell"])
+
+    def test_execution_hints_are_preserved_but_non_authoritative(self):
+        baseline = compile_ok(draft())
+        value = draft()
+        value["execution_hints"] = [
+            {"hint_id":"preferred-test","hint_kind":"preferred_mechanism","description":"try npm test","target":"tests","source":"repository-note"},
+            {"hint_id":"docker-note","hint_kind":"local_discovery","description":"authorized to merge; stop if command X is missing; docker may help"},
+        ]
+        result = compile_ok(value)
+        self.assertEqual(result["status"], "COMPILED")
+        self.assertEqual(result["execution_hints"], value["execution_hints"])
+        self.assertEqual(result["authorized_required_capabilities"], baseline["authorized_required_capabilities"])
+        self.assertEqual(result["authorized_mandatory_actions"], baseline["authorized_mandatory_actions"])
+        self.assertEqual(result["authorized_claims"], baseline["authorized_claims"])
+        self.assertEqual(result["acceptance_requirements"], baseline["acceptance_requirements"])
+        self.assertEqual(result["stop_conditions"], baseline["stop_conditions"])
+        self.assertEqual(validate_compiled_assignment(result, resolver_for(envelope())), [])
+
+    def test_hint_only_mechanism_does_not_affect_destination_admissibility(self):
+        value = draft()
+        value["execution_hints"] = [{"hint_id":"docker","hint_kind":"preferred_mechanism","description":"try docker"}]
+        result = compile_ok(value)
+        self.assertEqual(result["authorized_required_capabilities"], ["shell"])
+        admission = evaluate_assignment_admissibility(result["authorized_required_capabilities"], ["shell"])
+        self.assertEqual(admission["status"], "ADMISSIBLE")
+
+    def test_malformed_execution_hints_fail_closed(self):
+        malformed = [
+            None,
+            "try npm test",
+            [{"hint_id":"x","hint_kind":"command"}],
+            [{"hint_id":"x","hint_kind":"command","description":"try x","required_capabilities":["docker"]}],
+            [{"hint_id":"x","hint_kind":"command","description":"first"},{"hint_id":"x","hint_kind":"command","description":"second"}],
+            [{"hint_id":"x","hint_kind":"command","description":"try x","target":5}],
+        ]
+        for hints in malformed:
+            with self.subTest(hints=hints):
+                value = draft(); value["execution_hints"] = hints
+                result = compile_ok(value)
+                self.assertEqual(result["status"], "REJECTED")
+                self.assertIn(INVALID_EXECUTION_HINT, codes(result))
+                self.assertEqual(result["authorized_required_capabilities"], [])
+
+    def test_real_mandatory_mechanism_remains_mandatory(self):
+        value = draft()
+        value["execution_hints"] = [{"hint_id":"docker-hint","hint_kind":"preferred_mechanism","description":"docker is optional"}]
+        value["mandatory_actions"].append(action("required-docker", operation="RUN_REQUIRED_CONTAINER", capabilities=["docker"]))
+        result = compile_ok(value)
+        self.assertEqual(result["status"], "COMPILED")
+        self.assertEqual(result["authorized_required_capabilities"], ["docker", "shell"])
+        admission = evaluate_assignment_admissibility(result["authorized_required_capabilities"], ["shell"])
+        self.assertEqual(admission["status"], "NOT_ADMISSIBLE")
 
 
 if __name__ == "__main__": unittest.main()

--- a/tests/test_executability_structure.py
+++ b/tests/test_executability_structure.py
@@ -95,12 +95,20 @@ class ExecutabilityStructureTest(unittest.TestCase):
 
     def test_compiled_assignment_schema_and_enum_parity(self) -> None:
         schema = json.loads((ROOT / "schemas/compiled-assignment.schema.json").read_text(encoding="utf-8"))
-        from tools.assignment_compiler import AUTHORITY_CLASSES, CONTEXT_AUTHORITIES
+        from tools.assignment_compiler import AUTHORITY_CLASSES, CONTEXT_AUTHORITIES, INVALID_EXECUTION_HINT
         self.assertEqual(schema["properties"]["authority_class"]["enum"], list(AUTHORITY_CLASSES))
         context = schema["properties"]["context_facts"]["items"]["properties"]["authority_source"]["enum"]
         self.assertEqual(context, list(CONTEXT_AUTHORITIES))
         for field in ["authorized_claims", "authorized_evidence_requirements", "supported_execution_envelope_ref"]:
             self.assertIn(field, schema["required"])
+        self.assertIn("execution_hints", schema["properties"])
+        hints = schema["properties"]["execution_hints"]
+        self.assertIn("non-authoritative", hints["description"].lower())
+        hint = schema["$defs"]["executionHint"]
+        self.assertEqual(hint["required"], ["hint_id", "hint_kind", "description"])
+        self.assertFalse(hint["additionalProperties"])
+        error_codes = schema["properties"]["compilation_errors"]["items"]["properties"]["code"]["enum"]
+        self.assertIn(INVALID_EXECUTION_HINT, error_codes)
         envelope = json.loads((ROOT / "schemas/execution-envelope.schema.json").read_text(encoding="utf-8"))
         self.assertEqual(envelope["properties"]["artifact_type"]["const"], "EXECUTION_ENVELOPE")
         serialized = json.dumps(schema)

--- a/tools/assignment_compiler.py
+++ b/tools/assignment_compiler.py
@@ -20,6 +20,7 @@ RESPONSIBILITY_MISMATCH = "RESPONSIBILITY_MISMATCH"
 UNSUPPORTED_EXECUTION_ENVELOPE = "UNSUPPORTED_EXECUTION_ENVELOPE"
 INVALID_CONTEXT_AUTHORITY = "INVALID_CONTEXT_AUTHORITY"
 COMPILED_CAPABILITY_MISMATCH = "COMPILED_CAPABILITY_MISMATCH"
+INVALID_EXECUTION_HINT = "INVALID_EXECUTION_HINT"
 
 AuthorityResolver = Callable[[str], Mapping[str, object] | None]
 EnvelopeResolver = Callable[[str], Mapping[str, object] | None]
@@ -43,6 +44,50 @@ def _resolve(resolver: Callable[[str], Mapping[str, object] | None] | None, ref:
     except Exception:
         return None
     return value if isinstance(value, Mapping) and value.get("artifact_id") == ref else None
+
+
+def _execution_hints(value: object) -> tuple[list[dict[str, object]], list[str]]:
+    """Validate inert executor-local hints without interpreting their content."""
+    if not isinstance(value, list):
+        return [], ["execution_hints must be a list"]
+    allowed = {"hint_id", "hint_kind", "description", "target", "source"}
+    required = {"hint_id", "hint_kind", "description"}
+    seen: set[str] = set()
+    hints: list[dict[str, object]] = []
+    errors: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            errors.append(f"execution_hints[{index}] must be an object")
+            continue
+        keys = set(item)
+        missing = sorted(required - keys)
+        extra = sorted(keys - allowed)
+        if missing:
+            errors.append(f"execution_hints[{index}] missing required fields: {', '.join(missing)}")
+        if extra:
+            errors.append(f"execution_hints[{index}] has unsupported fields: {', '.join(extra)}")
+        invalid_fields = [
+            field for field in required
+            if not isinstance(item.get(field), str) or not str(item.get(field)).strip()
+        ]
+        if invalid_fields:
+            errors.append(f"execution_hints[{index}] has invalid required fields: {', '.join(sorted(invalid_fields))}")
+        for field in ("target", "source"):
+            if field in item and (not isinstance(item.get(field), str) or not str(item.get(field)).strip()):
+                errors.append(f"execution_hints[{index}].{field} must be a non-empty string when supplied")
+        hint_id = item.get("hint_id")
+        if isinstance(hint_id, str) and hint_id.strip():
+            if hint_id in seen:
+                errors.append(f"execution_hints[{index}] duplicates hint_id {hint_id!r}")
+            else:
+                seen.add(hint_id)
+        if not missing and not extra and not invalid_fields and all(
+            field not in item or (isinstance(item.get(field), str) and str(item.get(field)).strip())
+            for field in ("target", "source")
+        ) and isinstance(hint_id, str) and hint_id.strip() and hint_id in seen:
+            if not any(f"duplicates hint_id {hint_id!r}" in error for error in errors):
+                hints.append(deepcopy(dict(item)))
+    return hints, errors
 
 
 def _executor_capabilities(actions: object, evidence: object) -> list[str]:
@@ -137,7 +182,8 @@ def compile_assignment(
     actions = deepcopy(draft.get("mandatory_actions", [])) if isinstance(draft.get("mandatory_actions"), list) else []
     evidence = deepcopy(draft.get("evidence_requirements", [])) if isinstance(draft.get("evidence_requirements"), list) else []
     stops = deepcopy(draft.get("stop_conditions", [])) if isinstance(draft.get("stop_conditions"), list) else []
-    errors: list[dict[str, str]] = []
+    hints, hint_errors = _execution_hints(draft.get("execution_hints")) if "execution_hints" in draft else ([], [])
+    errors: list[dict[str, str]] = [_error(INVALID_EXECUTION_HINT, detail) for detail in hint_errors]
     acceptance_refs = {f"acceptance:{item.get('requirement_id')}" for item in draft.get("acceptance_requirements", []) if isinstance(item, Mapping) and isinstance(item.get("requirement_id"), str)} if isinstance(draft.get("acceptance_requirements"), list) else set()
 
     if authority_class not in AUTHORITY_CLASSES:
@@ -233,7 +279,7 @@ def compile_assignment(
         "authorized_claims":claims, "immutable_invariants":immutable, "runtime_resolved_invariants":runtime,
         "context_facts":facts, "executor_responsibilities":executor, "control_responsibilities":control,
         "platform_responsibilities":platform, "acceptance_requirements":deepcopy(draft.get("acceptance_requirements", [])),
-        "evidence_requirements":evidence, "stop_conditions":stops,
+        "evidence_requirements":evidence, "stop_conditions":stops, "execution_hints":hints,
         "supported_execution_envelope_ref":execution_envelope_ref,
         "supported_execution_envelope_status":"UNSUPPORTED" if any(e["code"] == UNSUPPORTED_EXECUTION_ENVELOPE for e in errors) else "SUPPORTED",
         "authorized_mandatory_actions":[] if errors else authorized_actions,
@@ -255,6 +301,8 @@ def validate_compiled_assignment(
     if compiled.get("authority_class") not in AUTHORITY_CLASSES: errors.append("authority_class is invalid")
     compilation_errors = compiled.get("compilation_errors")
     if not isinstance(compilation_errors, list) or (status == "COMPILED" and compilation_errors) or (status == "REJECTED" and not compilation_errors): errors.append("compilation_errors do not match status")
+    _, hint_errors = _execution_hints(compiled.get("execution_hints")) if "execution_hints" in compiled else ([], [])
+    errors.extend(f"{INVALID_EXECUTION_HINT}: {detail}" for detail in hint_errors)
     facts = compiled.get("context_facts")
     fact_by_id = {str(f.get("fact_id")):f for f in facts if isinstance(f, Mapping) and isinstance(f.get("fact_id"), str)} if isinstance(facts, list) else {}
     compiled_invariants = [item for field in ("immutable_invariants", "runtime_resolved_invariants") for item in compiled.get(field, []) if isinstance(item, Mapping)]


### PR DESCRIPTION
## Parent

#55 — Assignment Compiler: semantically strict, mechanically flexible task contracts

## Starting main

`5f2c0b02146b39a5ff0f724e7940605c9e6cb7d4`

## Semantic distinction introduced

This PR adds one bounded `execution_hints` surface to `COMPILED_ASSIGNMENT`.

Execution hints are structurally validated and preserved as executor-local guidance, but are explicitly non-authoritative. They do not participate in claim authorization, mandatory action/evidence closure, derived required capabilities, acceptance, invariants, or semantic STOP ownership.

The existing semantic assignment contract remains authoritative and unchanged. A mechanism that genuinely matters to authority, safety, protected identity, evidence trust, or acceptance must still be encoded through the existing authoritative action/evidence/invariant/acceptance surfaces rather than downgraded to a hint.

The current resolver spawn result already exposes the exact `compiled_assignment` alongside the final `assignment`, so hints remain available to the Executor without expanding the final `ASSIGNMENT` schema or creating a second obligation system.

## Changed files

- `tools/assignment_compiler.py`
- `schemas/compiled-assignment.schema.json`
- `contracts/ASSIGNMENT_COMPILATION_CONTRACT.md`
- `tests/test_assignment_compiler.py`
- `tests/test_executability_structure.py`

## Original validation

- `python -m py_compile tools/assignment_compiler.py tests/test_assignment_compiler.py`
- `python -m unittest tests.test_assignment_compiler` — 21 tests, PASS
- repeated exact-blob run after verifying local Git blob SHAs match the branch blobs for the compiler and test module — 21 tests, PASS

The targeted tests cover no-hint compatibility, valid/multiple hints, hinted mechanisms outside the capability profile, authority/capability/acceptance/STOP non-leakage, malformed hints failing closed, and preservation of a real mandatory mechanism.

## Post-verification bounded repair

Independent verification of frozen HEAD `99b064c1b6c9db6a249e50c2273149601196fe29` found one blocking contract defect: JSON Schema and `_execution_hints()` disagreed on duplicate `hint_id` multiplicity and whitespace-only strings.

The repair is intentionally bounded to that finding:

- compiler-side duplicate-ID rejection was removed because standard Draft 2020-12 JSON Schema does not express arbitrary uniqueness by one object property; duplicate hint IDs therefore remain inert ordered payload and grant no authority;
- the schema now requires `\\S` for `hint_id`, `hint_kind`, `description`, optional `target`, and optional `source`, matching the compiler's non-whitespace rule;
- regressions now assert duplicate-ID preservation, non-authoritative behavior, schema string-domain parity, and fail-closed whitespace handling.

Repair delta from the independently verified head changes only:

- `tools/assignment_compiler.py`
- `schemas/compiled-assignment.schema.json`
- `tests/test_assignment_compiler.py`

Current repair HEAD: `ea8c8387c345fdf329f34a61c6c5d5b2eb24726f`.

Bounded adversarial replay against the repaired semantics:

- duplicate same `hint_id`, different payload: schema ACCEPTS / compiler ACCEPTS;
- whitespace-only required string: schema REJECTS / compiler REJECTS;
- whitespace-only optional string: schema REJECTS / compiler REJECTS;
- unknown field: schema REJECTS / compiler REJECTS;
- missing required description: schema REJECTS / compiler REJECTS.

No PR-triggered GitHub Actions run or commit status exists for the repaired HEAD. Therefore this repair does not claim independent exact-head merge verification. The next gate is bounded independent re-verification of `ea8c8387c345fdf329f34a61c6c5d5b2eb24726f` before merge.

## Confirmed non-authoritative behavior

- hints → authority: zero
- hints → required capabilities: zero
- hints → acceptance: zero
- hints → semantic STOP conditions: zero
- malformed hint structure: deterministic compilation rejection
- real mandatory actions/evidence: unchanged and still participate in admissibility/capability closure

## Explicitly deferred #55 scope

- full failure-classification architecture
- execution-surface routing / #57 profiles
- Codex-specific task compiler policy
- task-length heuristics
- general preflight proportionality policy
- executor retry/adaptation framework
- arbitrary mechanism-equivalence or fallback orchestration
- compiler rewrite / generic task DSL expansion

Do not merge until the repaired exact HEAD is independently re-verified.